### PR TITLE
(feat) Support multiple Youtube urls

### DIFF
--- a/.changeset/tiny-meals-drive.md
+++ b/.changeset/tiny-meals-drive.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/video-embed': minor
+---
+
+Support multiple Youtube urls formats

--- a/packages/components/video-embed/src/lib/vimeo.ts
+++ b/packages/components/video-embed/src/lib/vimeo.ts
@@ -19,8 +19,15 @@ export const isVimeoUrl = (url: Maybe<string>): boolean => {
 
 /**
  * Get the Vimeo video ID from a URL
+ * The supported Vimeo URL formats is as follows:
+ * - https://vimeo.com/[VIDEO_ID]
  */
-export const getVimeoId = (url: string) => new URL(url).pathname.replace('/', '');
+export const getVimeoId = (url: string) => {
+	if (!URL.canParse(url)) {
+		return '';
+	}
+	return new URL(url).pathname.replace('/', '')
+};
 
 /**
  * Get the URL of a Vimeo video thumbnail. Make sure to setup the `vimeo-thumbnail.jpg` route in your app (see README).

--- a/packages/components/video-embed/src/lib/youtube.ts
+++ b/packages/components/video-embed/src/lib/youtube.ts
@@ -20,17 +20,60 @@ export const isYoutubeUrl = (url: Maybe<string>): boolean => {
 };
 
 /**
- * Get the YouTube video ID from a URL
+ * Get the YouTube video ID from a URL.
+ * YouTube urls can have different formats:
+ * - https://www.youtube.com/watch?v=[VIDEO_ID]
+ * - https://www.youtube.com/embed/[VIDEO_ID]
+ * - https://www.youtube.com/v/[VIDEO_ID]
+ * - https://www.youtube.com/watch/[VIDEO_ID]
+ * - https://www.youtube.com/shorts/[VIDEO_ID]
+ * - https://youtu.be/[VIDEO_ID]
+ *
+ * @param url The YouTube URL
  */
 export const getYoutubeId = (url: string) => {
 	if (!url) {
 		return '';
 	}
-	const urlObj = new URL(url);
-	if (urlObj.host === 'youtu.be') {
-		return urlObj.pathname.replace('/', '');
+	if (!URL.canParse(url)) {
+		return '';
 	}
-	return urlObj.searchParams.get('v');
+
+	const urlObj = new URL(url);
+
+	// Check search params first
+	if (urlObj.searchParams.has('v')) {
+		const v = urlObj.searchParams.get('v')?.trim();
+		if (v) {
+			return v;
+		}
+	}
+
+	const pathParts = urlObj.pathname.split('/').filter(Boolean);
+
+	// https://www.youtube.com/embed/[VIDEO_ID]
+	if (pathParts.length > 1 && pathParts[0] === 'embed') {
+		return pathParts[1];
+
+		// https://www.youtube.com/v/[VIDEO_ID]
+	} else if (pathParts.length > 1 && pathParts[0] === 'v') {
+		return pathParts[1];
+
+		// https://www.youtube.com/shorts/[VIDEO_ID]
+	} else if (pathParts.length > 1 && pathParts[0] === 'shorts') {
+		return pathParts[1];
+
+		// https://www.youtube.com/watch/[VIDEO_ID]
+	} else if (pathParts.length > 1 && pathParts[0] === 'watch') {
+		return pathParts[1];
+
+		// https://youtu.be/[VIDEO_ID]
+	} else if (pathParts.length === 1) {
+		return pathParts[0];
+	}
+
+	// Not found...
+	return '';
 };
 
 /**

--- a/packages/components/video-embed/test/youtube.spec.ts
+++ b/packages/components/video-embed/test/youtube.spec.ts
@@ -1,0 +1,37 @@
+
+import { expect, describe, test } from 'vitest';
+import { getYoutubeId } from '../src/lib/youtube';
+
+describe('getYoutubeId', () => {
+	test('?v=1234', () => {
+		const url = 'https://www.youtube.com/watch?v=1234';
+		expect(getYoutubeId(url)).toBe('1234');
+	});
+	test('embed/1234', () => {
+		const url = 'http://www.youtube.com/embed/1234';
+		expect(getYoutubeId(url)).toBe('1234');
+	});
+	test('v/1234', () => {
+		const url = 'https://youtube.com/v/1234';
+		expect(getYoutubeId(url)).toBe('1234');
+	});
+	test('shorts/1234', () => {
+		const url = 'https://www.youtube.com/shorts/1234';
+		expect(getYoutubeId(url)).toBe('1234');
+	});
+	test('watch/1234', () => {
+		const url = 'https://www.youtube.com/watch/1234';
+		expect(getYoutubeId(url)).toBe('1234');
+	});
+	test('youtu.be/1234', () => {
+		const url = 'https://youtu.be/1234';
+		expect(getYoutubeId(url)).toBe('1234');
+	});
+	test('Invalid url', () => {
+		const url = 'https//www.youtube.com/invalid/1234';
+		expect(getYoutubeId(url)).toBe('');
+	});
+	test('No url', () => {
+		expect(getYoutubeId('')).toBe('');
+	});
+});


### PR DESCRIPTION
This change makes it possible to supports many common urls patterns.

I've also added more documentation and a check to `URL.canParse()`.

This is really important as `new URL()` can throw.