### PR TITLE
(feat) Add parsedUrl() api

### DIFF
--- a/.changeset/unlucky-bears-perform.md
+++ b/.changeset/unlucky-bears-perform.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/url': minor
+---
+
+Add encodePath() function

--- a/packages/url/src/createEntryUrlBuilder.ts
+++ b/packages/url/src/createEntryUrlBuilder.ts
@@ -27,6 +27,13 @@ export const createEntryUrlBuilder = ({ siteUrl, localize, homeUri }: EntryUrlPa
 			 */
 			raw: url,
 			/**
+			 * Makes sure the pathname is properly encoded.
+			 * This can be needed when the pathname contains special characters.
+			 */
+			encodePath() {
+				url.pathname = encodeURIComponent(url.pathname);
+			},
+			/**
 			 * Returns the full URL string.
 			 */
 			toString() {

--- a/packages/url/src/parsedUrl.ts
+++ b/packages/url/src/parsedUrl.ts
@@ -1,0 +1,70 @@
+/**
+ * Safely parses a URL and expose and nice API to access the parts of the URL.
+ * If the URL is not valid, all functions returns null.
+ */
+export const parsedUrl = (url: string | URL) => {
+	const parsed = URL.canParse(url) ? new URL(url) : null;
+
+	const api = {
+		/**
+		 * The URL object.
+		 */
+		parsed,
+		valid: () => {
+			return parsed != null && parsed.toString() !== '';
+		},
+		/**
+		 * Makes sure the pathname is properly encoded.
+		 * This can be needed when the pathname contains special characters.
+		 */
+		encodePath: () => {
+			if (!parsed) {
+				return null;
+			}
+			parsed.pathname = encodeURIComponent(parsed.pathname);
+			return api;
+		},
+		/**
+		 * Returns the full URL string.
+		 */
+		toString: () => {
+			return parsed?.toString() ?? null;
+		},
+		/**
+		 * Returns the full URL string.
+		 */
+		toAbsolute: () => {
+			return parsed?.toString() ?? null;
+		},
+		/**
+		 * Returns the relative URL string.
+		 * It starts with a single slash.
+		 */
+		toRelative: () => {
+			if (!parsed) {
+				return null;
+			}
+			const { pathname, hash, search } = parsed;
+			return `${pathname}${search}${hash}`;
+		},
+		/**
+		 * Returns the URL string without the scheme, composed of the pathname, search, and hash.
+		 * It starts with a double slash.
+		 */
+		toSchemeLess: () => {
+			if (!parsed) {
+				return null;
+			}
+			const { hostname, pathname, hash, search } = parsed;
+			return `//${hostname}${pathname}${search}${hash}`;
+		},
+		parts: () => {
+			if (!parsed) {
+				return null;
+			}
+			return parsed.pathname.split('/').filter(Boolean);
+		},
+	};
+
+	return api;
+};

--- a/packages/url/test/parsedUrl.spec.ts
+++ b/packages/url/test/parsedUrl.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import { parsedUrl } from "../src/parsedUrl.js";
+
+describe('`parsed` property should return the url object', () => {
+	test('localized', () => {
+		const url = parsedUrl('https://example.com/path/to/resource');
+		expect(url.parsed).toMatchObject(new URL('https://example.com/path/to/resource'));
+	});
+});
+
+describe('`valid` property should return true if the url is valid', () => {
+	test('valid', () => {
+		const url = parsedUrl('https://example.com/path/to/resource');
+		expect(url.valid()).toBe(true);
+	});
+	test('invalid', () => {
+		const url = parsedUrl('invalid');
+		expect(url.valid()).toBe(false);
+	});
+});
+
+describe('`parts` property should return the parts of the url', () => {
+	test('valid', () => {
+		const url = parsedUrl('https://example.com/path/to/resource');
+		expect(url.parts()).toEqual(['path', 'to', 'resource']);
+	});
+});
+
+describe('`toString` method should return the url string', () => {
+	test('valid', () => {
+		const url = parsedUrl('https://example.com/path/to/resource');
+		expect(url.toString()).toBe('https://example.com/path/to/resource');
+	});
+});
+
+describe('`toAbsolute` method should return the absolute url string', () => {
+	test('valid', () => {
+		const url = parsedUrl('https://example.com/path/to/resource');
+		expect(url.toAbsolute()).toBe('https://example.com/path/to/resource');
+	});
+});
+
+describe('`toSchemeLess` method should return the url string without the scheme', () => {
+	test('valid', () => {
+		const url = parsedUrl('https://example.com/path/to/resource');
+		expect(url.toSchemeLess()).toBe('//example.com/path/to/resource');
+	});
+});

--- a/vitest.workspace.js
+++ b/vitest.workspace.js
@@ -4,5 +4,6 @@ export default defineWorkspace([
 	'./packages/i18n/src/vite.config.ts',
 	'./packages/format/vite.config.ts',
 	'./packages/http/vite.config.ts',
-	'./packages/dates/vite.config.ts'
+	'./packages/dates/vite.config.ts',
+	'./packages/url/vite.config.ts'
 ]);


### PR DESCRIPTION
Add thew new api as discussed.

(feat) Add `encodePath()` function
This makes it easy to encode paths on the fly, when needed.

