### PR TITLE
Properly handle muted and controls video attributes

### DIFF
--- a/.changeset/selfish-cheetahs-whisper.md
+++ b/.changeset/selfish-cheetahs-whisper.md
@@ -1,0 +1,5 @@
+---
+"@288-toolkit/html-elements": minor
+---
+
+Properly handle `muted` and `controls` video attributes

--- a/packages/components/html-elements/dist/HtmlAnchor.svelte.d.ts
+++ b/packages/components/html-elements/dist/HtmlAnchor.svelte.d.ts
@@ -1,3 +1,4 @@
+/// <reference types=".pnpm/svelte@4.2.17/node_modules/svelte" />
 import { SvelteComponent } from "svelte";
 import type { Maybe } from '@288-toolkit/types';
 declare const __propDef: {

--- a/packages/components/html-elements/dist/HtmlImg.svelte.d.ts
+++ b/packages/components/html-elements/dist/HtmlImg.svelte.d.ts
@@ -1,3 +1,4 @@
+/// <reference types=".pnpm/svelte@4.2.17/node_modules/svelte" />
 import { SvelteComponent } from "svelte";
 import type { Maybe } from '@288-toolkit/types';
 declare const __propDef: {

--- a/packages/components/html-elements/dist/HtmlTime.svelte.d.ts
+++ b/packages/components/html-elements/dist/HtmlTime.svelte.d.ts
@@ -1,3 +1,4 @@
+/// <reference types=".pnpm/svelte@4.2.17/node_modules/svelte" />
 import { SvelteComponent } from "svelte";
 declare const __propDef: {
     props: {

--- a/packages/components/html-elements/dist/HtmlVideo.svelte
+++ b/packages/components/html-elements/dist/HtmlVideo.svelte
@@ -3,29 +3,24 @@
 	export let disableremoteplayback = true;
 	export let muted = false;
 	export let controls = true;
-	export let el: HTMLVideoElement | undefined = undefined;
-
-	const updateAttribute = (attr: string, value: boolean) => {
-		if (el) {
-			el[attr] = value;
-		}
-	};
 
 	// These attributes are not well handled by Svelte (see https://github.com/sveltejs/svelte/issues/6536)
 	// so we update them manually
-	$: if (el) {
-		updateAttribute('muted', muted);
-		updateAttribute('controls', controls);
-	}
+	const setAttributes = (el: HTMLVideoElement) => {
+		el.muted = muted;
+		el.controls = controls;
+	};
 </script>
 
 <!-- svelte-ignore a11y-media-has-caption -->
 <video
 	autoplay={autoplay ? true : null}
-	playsinline={autoplay || null}
+	playsinline={autoplay ? true : null}
+	muted={muted ? true : null}
+	controls={controls ? true : null}
 	{disableremoteplayback}
 	x-webkit-airplay={disableremoteplayback ? 'deny' : 'allow'}
-	bind:this={el}
+	use:setAttributes
 	{...$$restProps}
 >
 	<slot />

--- a/packages/components/html-elements/dist/HtmlVideo.svelte
+++ b/packages/components/html-elements/dist/HtmlVideo.svelte
@@ -11,6 +11,8 @@
 		}
 	};
 
+	// These attributes are not well handled by Svelte (see https://github.com/sveltejs/svelte/issues/6536)
+	// so we update them manually
 	$: if (el) {
 		updateAttribute('muted', muted);
 		updateAttribute('controls', controls);

--- a/packages/components/html-elements/dist/HtmlVideo.svelte
+++ b/packages/components/html-elements/dist/HtmlVideo.svelte
@@ -1,14 +1,29 @@
 <script lang="ts">
 	export let autoplay = false;
 	export let disableremoteplayback = true;
+	export let muted = false;
+	export let controls = true;
+	export let el: HTMLVideoElement | undefined = undefined;
+
+	const updateAttribute = (attr: string, value: boolean) => {
+		if (el) {
+			el[attr] = value;
+		}
+	};
+
+	$: if (el) {
+		updateAttribute('muted', muted);
+		updateAttribute('controls', controls);
+	}
 </script>
 
 <!-- svelte-ignore a11y-media-has-caption -->
 <video
+	autoplay={autoplay ? true : null}
 	playsinline={autoplay || null}
-	{autoplay}
 	{disableremoteplayback}
 	x-webkit-airplay={disableremoteplayback ? 'deny' : 'allow'}
+	bind:this={el}
 	{...$$restProps}
 >
 	<slot />

--- a/packages/components/html-elements/dist/HtmlVideo.svelte.d.ts
+++ b/packages/components/html-elements/dist/HtmlVideo.svelte.d.ts
@@ -1,3 +1,4 @@
+/// <reference types=".pnpm/svelte@4.2.17/node_modules/svelte" />
 import { SvelteComponent } from "svelte";
 declare const __propDef: {
     props: {

--- a/packages/components/html-elements/dist/HtmlVideo.svelte.d.ts
+++ b/packages/components/html-elements/dist/HtmlVideo.svelte.d.ts
@@ -4,6 +4,9 @@ declare const __propDef: {
         [x: string]: any;
         autoplay?: boolean | undefined;
         disableremoteplayback?: boolean | undefined;
+        muted?: boolean | undefined;
+        controls?: boolean | undefined;
+        el?: HTMLVideoElement | undefined;
     };
     events: {
         [evt: string]: CustomEvent<any>;

--- a/packages/components/html-elements/dist/HtmlVideo.svelte.d.ts
+++ b/packages/components/html-elements/dist/HtmlVideo.svelte.d.ts
@@ -7,7 +7,6 @@ declare const __propDef: {
         disableremoteplayback?: boolean | undefined;
         muted?: boolean | undefined;
         controls?: boolean | undefined;
-        el?: HTMLVideoElement | undefined;
     };
     events: {
         [evt: string]: CustomEvent<any>;

--- a/packages/components/html-elements/src/lib/HtmlVideo.svelte
+++ b/packages/components/html-elements/src/lib/HtmlVideo.svelte
@@ -3,29 +3,24 @@
 	export let disableremoteplayback = true;
 	export let muted = false;
 	export let controls = true;
-	export let el: HTMLVideoElement | undefined = undefined;
-
-	const updateAttribute = (attr: string, value: boolean) => {
-		if (el) {
-			el[attr] = value;
-		}
-	};
 
 	// These attributes are not well handled by Svelte (see https://github.com/sveltejs/svelte/issues/6536)
 	// so we update them manually
-	$: if (el) {
-		updateAttribute('muted', muted);
-		updateAttribute('controls', controls);
-	}
+	const setAttributes = (el: HTMLVideoElement) => {
+		el.muted = muted;
+		el.controls = controls;
+	};
 </script>
 
 <!-- svelte-ignore a11y-media-has-caption -->
 <video
 	autoplay={autoplay ? true : null}
-	playsinline={autoplay || null}
+	playsinline={autoplay ? true : null}
+	muted={muted ? true : null}
+	controls={controls ? true : null}
 	{disableremoteplayback}
 	x-webkit-airplay={disableremoteplayback ? 'deny' : 'allow'}
-	bind:this={el}
+	use:setAttributes
 	{...$$restProps}
 >
 	<slot />

--- a/packages/components/html-elements/src/lib/HtmlVideo.svelte
+++ b/packages/components/html-elements/src/lib/HtmlVideo.svelte
@@ -11,6 +11,8 @@
 		}
 	};
 
+	// These attributes are not well handled by Svelte (see https://github.com/sveltejs/svelte/issues/6536)
+	// so we update them manually
 	$: if (el) {
 		updateAttribute('muted', muted);
 		updateAttribute('controls', controls);

--- a/packages/components/html-elements/src/lib/HtmlVideo.svelte
+++ b/packages/components/html-elements/src/lib/HtmlVideo.svelte
@@ -1,14 +1,29 @@
 <script lang="ts">
 	export let autoplay = false;
 	export let disableremoteplayback = true;
+	export let muted = false;
+	export let controls = true;
+	export let el: HTMLVideoElement | undefined = undefined;
+
+	const updateAttribute = (attr: string, value: boolean) => {
+		if (el) {
+			el[attr] = value;
+		}
+	};
+
+	$: if (el) {
+		updateAttribute('muted', muted);
+		updateAttribute('controls', controls);
+	}
 </script>
 
 <!-- svelte-ignore a11y-media-has-caption -->
 <video
+	autoplay={autoplay ? true : null}
 	playsinline={autoplay || null}
-	{autoplay}
 	{disableremoteplayback}
 	x-webkit-airplay={disableremoteplayback ? 'deny' : 'allow'}
+	bind:this={el}
 	{...$$restProps}
 >
 	<slot />


### PR DESCRIPTION
For some reason Svelte doesn't correctly handle those attributes (see https://github.com/sveltejs/svelte/issues/6536). I don't know how we didn't catch this earlier, but this PR works around the issue.

Closes https://github.com/DeuxHuitHuit/288-toolkit/issues/9