### PR TITLE
Svelte 5 - video-embed & html-elements

### DIFF
--- a/.changeset/chilly-moles-rush.md
+++ b/.changeset/chilly-moles-rush.md
@@ -1,0 +1,6 @@
+---
+'@288-toolkit/html-elements': major
+'@288-toolkit/video-embed': major
+---
+
+Breaking: upgrade to svelte 5

--- a/.changeset/poor-bugs-relate.md
+++ b/.changeset/poor-bugs-relate.md
@@ -1,5 +1,0 @@
----
-"@288-toolkit/html-elements": major
----
-
-Migrate to svelte 5

--- a/packages/components/html-elements/README.md
+++ b/packages/components/html-elements/README.md
@@ -8,10 +8,10 @@ A collection of convenient wrapper components around basic html elements.
 
 ## `HtmlAnchor.svelte`
 
-Renders a HTML link (anchor). External links will have `noopener noreferrer` rel and `_blank` target
-attributes applied. The only required prop is `href`.
+Renders an HTML link (anchor). External links will have `noopener noreferrer` rel and `_blank`
+target attributes applied. The only required prop is `href`.
 
-## Slot props
+## Children props
 
 -   `external` (`boolean`): Wether the url is an external url.
 
@@ -41,7 +41,7 @@ A wrapper component arund the <time> html element.
 -   `formatOptions` (`FormatDateOptions`): The date formatting options (see
     [format package](../format/README.md))
 
-## Slot props
+## Children props
 
 -   `formattedDate` (`string`): The formatted date
 
@@ -55,13 +55,11 @@ A wrapper component arund the <time> html element.
 ```
 
 ```svelte
-<Time
-	date={new Date('2023-04-17T21:34:50.360Z')}
-	formatOptions={{ day: 'numeric', month: 'long' }}
-	let:formattedDate
->
-	<span class="text-[red]">
-		{formattedDate}
-	</span>
+<Time date={new Date('2023-04-17T21:34:50.360Z')} formatOptions={{ day: 'numeric', month: 'long' }}>
+	{#snippet children({ formattedDate })}
+		<span class="text-[red]">
+			{formattedDate}
+		</span>
+	{/snippet}
 </Time>
 ```

--- a/packages/components/html-elements/src/lib/HtmlAnchor.svelte
+++ b/packages/components/html-elements/src/lib/HtmlAnchor.svelte
@@ -7,7 +7,7 @@
 		rel?: Maybe<string>;
 		target?: Maybe<string>;
 		children?: import('svelte').Snippet<[{ external: boolean }]>;
-		[key: string]: any;
+		[key: string]: unknown;
 	}
 
 	let { href, rel = null, target = null, children, ...rest }: Props = $props();

--- a/packages/components/html-elements/src/lib/HtmlImg.svelte
+++ b/packages/components/html-elements/src/lib/HtmlImg.svelte
@@ -5,7 +5,7 @@
 		src: Maybe<string>;
 		srcset?: Maybe<string>;
 		alt?: Maybe<string>;
-		[key: string]: any;
+		[key: string]: unknown;
 	}
 
 	let { src, srcset = null, alt = null, ...rest }: Props = $props();

--- a/packages/components/html-elements/src/lib/HtmlVideo.svelte
+++ b/packages/components/html-elements/src/lib/HtmlVideo.svelte
@@ -3,7 +3,7 @@
 		autoplay?: boolean;
 		disableremoteplayback?: boolean;
 		children?: import('svelte').Snippet;
-		[key: string]: any;
+		[key: string]: unknown;
 	}
 
 	let { autoplay = false, disableremoteplayback = true, children, ...rest }: Props = $props();

--- a/packages/components/video-embed/README.md
+++ b/packages/components/video-embed/README.md
@@ -101,7 +101,7 @@ The Vimeo embed component. Automatically rendered by `ProviderSelector`.
 <script lang="ts">
 	import type { AssetInterface } from 'src/craft';
 	import { fade } from 'svelte/transition';
-	import VideoEmbed from '@288-toolkit/video-embed';
+	import { VideoEmbed } from '@288-toolkit/video-embed';
 	import PlayIcon from '$com/ui/PlayIcon.svelte';
 	import Media from '$com/ui/Media.svelte';
 
@@ -182,3 +182,27 @@ import { vimeoThumbnailHandler } from '@288-toolkit/video-embed';
 
 export const GET = vimeoThumbnailHandler;
 ```
+
+## Migration from latest Svelte 4 version
+
+-   Translations have been removed. Make sure to remove them from your translation loader.
+-   The `PlayButton` component now requires a `label` prop for screen readers.
+-   Individual component imports have been deprecated. While they still work, prefer using the
+    `VideoEmbed` export instead and use dot notation to access the components (see examples above).
+-   The `useVideoEmbed()` function has replaced `getVideoEmbedContext()`.
+-   When using the api via context, make sure to access `playing` and `preconnect` directly on the
+    variable instead of destructuring them. This keeps the values reactive.
+
+    ```ts
+    // Good
+    const api = useVideoEmbed();
+
+    api.playing;
+    api.preconnect;
+
+    // Bad
+    const { playing, preconnect } = useVideoEmbed();
+
+    playing;
+    preconnect;
+    ```

--- a/packages/components/video-embed/README.md
+++ b/packages/components/video-embed/README.md
@@ -2,19 +2,35 @@
 
 A collection of Svelte components and functions to work with Vimeo and Youtube embeds.
 
-## Components
+## Structure
 
-### `EmbedGroup.svelte`
+```svelte
+<script>
+	import { VideoEmbed } from '@288-toolkit/video-embed';
 
-An embed group that provides a context for video embeds.
+	const embedUrl = 'https://youtube.com/watch?v=dQw4w9WgXcQ';
+</script>
 
-#### Props
+<VideoEmbed.Root url={embedUrl} let:playing>
+	{#snippet children({ playing })}
+		<VideoEmbed.ProviderSelector />
+		<!-- Or -->
+		<VideoEmbed.Youtube />
+		<!-- Or -->
+		<VideoEmbed.Vimeo />
+		{#if !playing}
+			<VideoEmbed.PlayButton>
+				<VideoEmbed.Thumbnail />
+			</VideoEmbed.PlayButton>
+		{/if}
+	{/snippet}
+</VideoEmbed.Root>
+```
 
--   `url` (`string`): The url of the video.
+## Api
 
-#### Slot props
-
-Slot props are also available via `getVideoEmbedContext()`.
+The video embed Api is available via `useVideoEmbed()` as well as the `Root` component children
+props.
 
 -   `playing` (`boolean`): `true` if the video embed is currently loaded and playing.
 -   `play` (`() => void`): Play the video.
@@ -22,50 +38,62 @@ Slot props are also available via `getVideoEmbedContext()`.
 -   `preconnect` (`boolean`): `true` if preconnect has been requested
 -   `url` (`string`): The URL of the video
 
+## Components
+
+### `Root`
+
+Provides the context for the other components.
+
+#### Props
+
+-   `url` (`string`): The url of the video.
+
+#### Children props
+
+The video embed Api.
+
 ### `EmbedPlayButton.svelte`
 
 A button that calls `requestPreconnect` when hovered and plays the video on click.
 
 #### Props
 
--   `class` (`string`): The classes to apply to the button element.
+-   `label` (`string`): The aria-label to use for the button. REQUIRED.
 
-### `EmbedThumbnail.svelte`
+### `Thumbnail.svelte`
 
 An img element that renders the default video thumbnail. Make sure to setup the
 `vimeo-thumbnail.jpg` endpoint before using (documented below).
 
 #### Props
 
--   `url` (`string`): The url of the video. Already provided if this component is used inside an
-    `EmbedGroup`.
+-   `url` (`string`): The url of the video. Already provided if this component is used inside an a
+    `Root` component.
 -   `alt` (`string`): The alt text for the image.
--   `class` (`string`): The classes to apply to the img element.
 
-### `EmbedSelector.svelte`
+### `ProviderSelector.svelte`
 
 A selector component that automatically determines the provider and renders the appropriate embed.
-For more control over how the markup is rendered, the component has a slot that provides the embed
-component.
+For more control over how the markup is rendered, the component has a children prop that provides
+the embed component.
 
 #### Props
 
--   `url` (`string`): The url of the video. Already provided if this component is used inside an
-    `EmbedGroup`.
+-   `url` (`string`): The url of the video. Already provided if this component is used inside a
+    `Root` component.
 
-#### Slot props
+#### Children props
 
 -   `provider` (`'vimeo' | 'youtube'`): The embed provider, determined from the url.
-
 -   `EmbedComponent` (`SvelteComponent`): The Svelte component of the embed.
 
-### `YoutubeEmbed.svelte`
+### `Youtube.svelte`
 
-The Youtube embed component. Automatically rendered by `EmbedSelector`.
+The Youtube embed component. Automatically rendered by `ProviderSelector`.
 
-### `VimeoEmbed.svelte`
+### `Vimeo.svelte`
 
-The Vimeo embed component. Automatically rendered by `EmbedSelector`.
+The Vimeo embed component. Automatically rendered by `ProviderSelector`.
 
 ## Example
 
@@ -73,39 +101,45 @@ The Vimeo embed component. Automatically rendered by `EmbedSelector`.
 <script lang="ts">
 	import type { AssetInterface } from 'src/craft';
 	import { fade } from 'svelte/transition';
-	import EmbedGroup from '$com/ui/video-embed/EmbedGroup.svelte';
-	import EmbedSelector from '$com/ui/video-embed/EmbedSelector.svelte';
-	import EmbedPoster from '$com/ui/video-embed/decoration/EmbedPoster.svelte';
-	import EmbedPlayButton from '$com/ui/video-embed/decoration/EmbedPlayButton.svelte';
+	import VideoEmbed from '@288-toolkit/video-embed';
 	import PlayIcon from '$com/ui/PlayIcon.svelte';
-	import LazyMedia from '$com/ui/LazyMedia.svelte';
+	import Media from '$com/ui/Media.svelte';
 
-	export let embedUrl: Maybe<string>;
-	export let poster: Maybe<AssetInterface>;
+	const {
+		embedUrl,
+		poster
+	}: {
+		embedUrl: Maybe<string>;
+		poster: Maybe<AssetInterface>;
+	} = $props();
 </script>
 
-<EmbedGroup url={embedUrl} let:playing>
+<VideoEmbed.Root url={embedUrl} let:playing>
 	<div class="grid-stack grid aspect-[2/1] w-full overflow-hidden rounded">
-		<EmbedSelector />
+		<VideoEmbed.ProviderSelector class="size-full" />
 		{#if !playing}
-			<div class="h-full w-full" out:fade={{ duration: 200 }}>
-				<EmbedPlayButton>
-					<div class="grid-stack grid h-full w-full place-items-center">
+			<div class="size-full" out:fade={{ duration: 200 }}>
+				<VideoEmbed.PlayButton>
+					<div class="grid-stack grid size-full place-items-center">
 						{#if poster}
-							<Media media={poster} class="h-full w-full object-cover" />
+							<Media media={poster} class="size-full object-cover" />
 						{:else}
-							<EmbedThumbnail />
+							<VideoEmbed.Thumbnail />
 						{/if}
 						<PlayIcon />
 					</div>
-				</EmbedPlayButton>
+				</VideoEmbed.PlayButton>
 			</div>
 		{/if}
 	</div>
-</EmbedGroup>
+</VideoEmbed.Root>
 ```
 
 ## Functions
+
+### `useVideoEmbed()`
+
+Returns the video embed Api if used inside a `Root` component, otherwise returns `null`.
 
 ### `isYoutubeUrl()`
 
@@ -119,7 +153,7 @@ Get the YouTube video ID from a URL
 
 Get the URL of a YouTube video thumbnail
 
-## `isVimeoUrl()`
+### `isVimeoUrl()`
 
 Check if a URL is a valid Vimeo URL
 

--- a/packages/components/video-embed/package.json
+++ b/packages/components/video-embed/package.json
@@ -25,10 +25,6 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
-		},
-		"./translations": {
-			"types": "./dist/translations/loader.d.ts",
-			"svelte": "./dist/translations/loader.js"
 		}
 	},
 	"peerDependencies": {
@@ -37,16 +33,14 @@
 	},
 	"dependencies": {
 		"@288-toolkit/html-elements": "workspace:*",
-		"@288-toolkit/i18n": "workspace:*",
 		"@288-toolkit/strings": "workspace:*",
-		"@288-toolkit/typed-context": "workspace:*",
 		"@288-toolkit/types": "workspace:*",
 		"@288-toolkit/vite-plugin-svelte-inline-component": "workspace:*",
-		"@testing-library/svelte": "^5.1.0"
+		"@testing-library/svelte": "^5.1.0",
+		"runed": "^0.23.0"
 	},
 	"devDependencies": {
 		"@testing-library/jest-dom": "^6.6.3",
-		"svelte-preprocess": "^6.0.0",
 		"vitest": "link:@testing-library/jest-dom/vitest"
 	}
 }

--- a/packages/components/video-embed/package.json
+++ b/packages/components/video-embed/package.json
@@ -33,7 +33,7 @@
 	},
 	"peerDependencies": {
 		"@sveltejs/kit": "2.x",
-		"svelte": "4.x || 5.x"
+		"svelte": "5.x"
 	},
 	"dependencies": {
 		"@288-toolkit/html-elements": "workspace:*",
@@ -45,6 +45,8 @@
 		"@testing-library/svelte": "^5.1.0"
 	},
 	"devDependencies": {
-		"svelte-preprocess": "5.1.4"
+		"@testing-library/jest-dom": "^6.6.3",
+		"svelte-preprocess": "^6.0.0",
+		"vitest": "link:@testing-library/jest-dom/vitest"
 	}
 }

--- a/packages/components/video-embed/src/lib/EmbedGroup.svelte
+++ b/packages/components/video-embed/src/lib/EmbedGroup.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
 	import { writable, type Readable, readonly } from 'svelte/store';
 	import type { Maybe } from '@288-toolkit/types';
 	import { createTypedContext } from '@288-toolkit/typed-context';
@@ -34,7 +34,21 @@
 </script>
 
 <script lang="ts">
-	export let url: Maybe<string> = null;
+	interface Props {
+		url?: Maybe<string>;
+		children?: import('svelte').Snippet<
+			[
+				{
+					playing: boolean;
+					preconnect: boolean;
+					play: () => void;
+					requestPreconnect: () => void;
+				}
+			]
+		>;
+	}
+
+	let { url = null, children }: Props = $props();
 
 	interface $$Slots {
 		default: {
@@ -65,4 +79,4 @@
 	});
 </script>
 
-<slot playing={$playing} preconnect={$preconnect} {play} {requestPreconnect} />
+{@render children?.({ playing: $playing, preconnect: $preconnect, play, requestPreconnect })}

--- a/packages/components/video-embed/src/lib/EmbedGroup.svelte
+++ b/packages/components/video-embed/src/lib/EmbedGroup.svelte
@@ -1,82 +1,15 @@
-<script module lang="ts">
-	import { writable, type Readable, readonly } from 'svelte/store';
-	import type { Maybe } from '@288-toolkit/types';
-	import { createTypedContext } from '@288-toolkit/typed-context';
-
-	export interface VideoEmbedApi {
-		/**
-		 * A readable store that indicates if the video is currently playing
-		 */
-		playing: Readable<boolean>;
-		/**
-		 * A readable store that indicates if preconnect has been requested
-		 */
-		preconnect: Readable<boolean>;
-		/**
-		 * Request preconnect
-		 */
-		requestPreconnect: () => void;
-		/**
-		 * Play the video
-		 */
-		play: () => void;
-		/**
-		 * The URL of the video
-		 */
-		url: Maybe<string>;
-	}
-
-	const CONTEXT_KEY = '__videoEmbed__';
-
-	const { setContext, getContext } = createTypedContext<VideoEmbedApi>(CONTEXT_KEY);
-
-	export const getVideoEmbedContext = getContext;
-</script>
-
 <script lang="ts">
+	import type { Maybe } from '@288-toolkit/types';
+	import { VideoEmbedApi, videoEmbedContext } from './videoEmbed.svelte.js';
+
 	interface Props {
 		url?: Maybe<string>;
-		children?: import('svelte').Snippet<
-			[
-				{
-					playing: boolean;
-					preconnect: boolean;
-					play: () => void;
-					requestPreconnect: () => void;
-				}
-			]
-		>;
+		children?: import('svelte').Snippet<[VideoEmbedApi]>;
 	}
 
 	let { url = null, children }: Props = $props();
 
-	interface $$Slots {
-		default: {
-			playing: boolean;
-			preconnect: boolean;
-			play: () => void;
-			requestPreconnect: () => void;
-		};
-	}
-
-	const playing = writable(false);
-	const preconnect = writable(false);
-
-	const requestPreconnect = () => {
-		preconnect.set(true);
-	};
-
-	const play = () => {
-		playing.set(true);
-	};
-
-	setContext({
-		playing: readonly(playing),
-		preconnect: readonly(preconnect),
-		requestPreconnect,
-		play,
-		url
-	});
+	const api = videoEmbedContext.set(new VideoEmbedApi(url));
 </script>
 
-{@render children?.({ playing: $playing, preconnect: $preconnect, play, requestPreconnect })}
+{@render children?.(api)}

--- a/packages/components/video-embed/src/lib/EmbedPlayButton.svelte
+++ b/packages/components/video-embed/src/lib/EmbedPlayButton.svelte
@@ -1,27 +1,22 @@
 <script lang="ts">
-	import { t } from './translations/index.js';
-	import { getVideoEmbedContext } from './EmbedGroup.svelte';
+	import { videoEmbedContext } from './videoEmbed.svelte.js';
 
 	interface Props {
-		class?: string;
+		/**
+		 * The aria-label to use for the button. REQUIRED.
+		 */
+		label: string;
 		children?: import('svelte').Snippet;
+		[key: string]: unknown;
 	}
 
-	let { class: classes = '', children }: Props = $props();
-	/**
-	 * The classes to apply to the button element.
-	 */
+	let { label, children, ...rest }: Props = $props();
 
-	const api = getVideoEmbedContext();
+	const api = videoEmbedContext.get();
+
 	const { requestPreconnect, play } = api;
 </script>
 
-<button
-	class={classes}
-	type="button"
-	onpointerover={requestPreconnect}
-	onclick={play}
-	aria-label={t('play')}
->
+<button type="button" onpointerover={requestPreconnect} onclick={play} aria-label={label} {...rest}>
 	{@render children?.()}
 </button>

--- a/packages/components/video-embed/src/lib/EmbedPlayButton.svelte
+++ b/packages/components/video-embed/src/lib/EmbedPlayButton.svelte
@@ -2,11 +2,15 @@
 	import { t } from './translations/index.js';
 	import { getVideoEmbedContext } from './EmbedGroup.svelte';
 
-	let classes = '';
+	interface Props {
+		class?: string;
+		children?: import('svelte').Snippet;
+	}
+
+	let { class: classes = '', children }: Props = $props();
 	/**
 	 * The classes to apply to the button element.
 	 */
-	export { classes as class };
 
 	const api = getVideoEmbedContext();
 	const { requestPreconnect, play } = api;
@@ -15,9 +19,9 @@
 <button
 	class={classes}
 	type="button"
-	on:pointerover={requestPreconnect}
-	on:click={play}
+	onpointerover={requestPreconnect}
+	onclick={play}
 	aria-label={t('play')}
 >
-	<slot />
+	{@render children?.()}
 </button>

--- a/packages/components/video-embed/src/lib/EmbedSelector.svelte
+++ b/packages/components/video-embed/src/lib/EmbedSelector.svelte
@@ -5,11 +5,24 @@
 	import YtEmbed from './YoutubeEmbed.svelte';
 	import VimeoEmbed from './VimeoEmbed.svelte';
 	import type { Maybe } from '@288-toolkit/types';
+	import { Component } from 'svelte';
 
-	/**
-	 * The url of the video. Already provided if this component is used inside an EmbedGroup.
-	 */
-	export let url: Maybe<string> = getVideoEmbedContext()?.url;
+	interface Props {
+		/**
+		 * The url of the video. Already provided if this component is used inside an EmbedGroup.
+		 */
+		url?: Maybe<string>;
+		children?: import('svelte').Snippet<
+			[
+				{
+					provider: Maybe<keyof typeof providers>;
+					EmbedComponent: Component;
+				}
+			]
+		>;
+	}
+
+	let { url = getVideoEmbedContext()?.url, children }: Props = $props();
 
 	const providers = {
 		youtube: YtEmbed,
@@ -25,8 +38,8 @@
 	const EmbedComponent = provider ? providers[provider] : null;
 </script>
 
-<slot {provider} {EmbedComponent}>
-	{#if EmbedComponent}
-		<svelte:component this={EmbedComponent} {url} />
-	{/if}
-</slot>
+{#if children}
+	{@render children({ provider, EmbedComponent })}
+{:else if EmbedComponent}
+	<EmbedComponent {url} />
+{/if}

--- a/packages/components/video-embed/src/lib/EmbedSelector.svelte
+++ b/packages/components/video-embed/src/lib/EmbedSelector.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
 	import { isYoutubeUrl } from './youtube.js';
 	import { isVimeoUrl } from './vimeo.js';
-	import { getVideoEmbedContext } from './EmbedGroup.svelte';
 	import YtEmbed from './YoutubeEmbed.svelte';
 	import VimeoEmbed from './VimeoEmbed.svelte';
 	import type { Maybe } from '@288-toolkit/types';
 	import { Component } from 'svelte';
+	import { videoEmbedContext } from './videoEmbed.svelte.js';
+
+	const providers = {
+		youtube: YtEmbed,
+		vimeo: VimeoEmbed
+	};
+
+	const api = videoEmbedContext.get();
 
 	interface Props {
 		/**
@@ -22,12 +29,7 @@
 		>;
 	}
 
-	let { url = getVideoEmbedContext()?.url, children }: Props = $props();
-
-	const providers = {
-		youtube: YtEmbed,
-		vimeo: VimeoEmbed
-	};
+	let { url = api?.url, children }: Props = $props();
 
 	const provider: Maybe<keyof typeof providers> = isYoutubeUrl(url)
 		? 'youtube'

--- a/packages/components/video-embed/src/lib/EmbedThumbnail.svelte
+++ b/packages/components/video-embed/src/lib/EmbedThumbnail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getVimeoThumbnailUrl, isVimeoUrl } from './vimeo.js';
 	import { getYoutubeThumbnailUrl, isYoutubeUrl } from './youtube.js';
-	import { getVideoEmbedContext } from './EmbedGroup.svelte';
+	import { videoEmbedContext } from './videoEmbed.svelte.js';
 	import type { Maybe } from '@288-toolkit/types';
 	import { HtmlImg } from '@288-toolkit/html-elements';
 
@@ -14,13 +14,12 @@
 		 * The alt text for the image.
 		 */
 		alt?: Maybe<string>;
-		class?: string;
+		[key: string]: unknown;
 	}
 
-	let { url = getVideoEmbedContext()?.url, alt = null, class: classes = '' }: Props = $props();
-	/**
-	 * The classes to apply to the img element.
-	 */
+	const api = videoEmbedContext.get();
+
+	let { url = api?.url, alt = null, ...rest }: Props = $props();
 
 	const getVendorThumbnailUrl = () => {
 		if (!url) {
@@ -36,4 +35,4 @@
 	const posterSrc = getVendorThumbnailUrl();
 </script>
 
-<HtmlImg src={posterSrc} {alt} class={classes} />
+<HtmlImg src={posterSrc} {alt} {...rest} />

--- a/packages/components/video-embed/src/lib/EmbedThumbnail.svelte
+++ b/packages/components/video-embed/src/lib/EmbedThumbnail.svelte
@@ -5,19 +5,22 @@
 	import type { Maybe } from '@288-toolkit/types';
 	import { HtmlImg } from '@288-toolkit/html-elements';
 
-	/**
-	 * The url of the video. Already provided if this component is used inside an EmbedGroup.
-	 */
-	export let url: Maybe<string> = getVideoEmbedContext()?.url;
-	/**
-	 * The alt text for the image.
-	 */
-	export let alt: Maybe<string> = null;
-	let classes = '';
+	interface Props {
+		/**
+		 * The url of the video. Already provided if this component is used inside an EmbedGroup.
+		 */
+		url?: Maybe<string>;
+		/**
+		 * The alt text for the image.
+		 */
+		alt?: Maybe<string>;
+		class?: string;
+	}
+
+	let { url = getVideoEmbedContext()?.url, alt = null, class: classes = '' }: Props = $props();
 	/**
 	 * The classes to apply to the img element.
 	 */
-	export { classes as class };
 
 	const getVendorThumbnailUrl = () => {
 		if (!url) {

--- a/packages/components/video-embed/src/lib/VimeoEmbed.svelte
+++ b/packages/components/video-embed/src/lib/VimeoEmbed.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
 	export type VimeoEmbedOptions = {
 		h?: string;
 		title?: boolean | string; // show title
@@ -22,13 +22,25 @@
 	import { objectToQueryString } from '@288-toolkit/strings';
 	import type { Maybe } from '@288-toolkit/types';
 
-	export let url: Maybe<string>;
-	export let title: Maybe<string> = null;
-	export let muted = false;
-	export let autoplay = true;
-	export let loop = false;
-	export let start: Maybe<number> = null;
-	export let options: VimeoEmbedOptions = VIMEO_DEFAULTS;
+	interface Props {
+		url: Maybe<string>;
+		title?: Maybe<string>;
+		muted?: boolean;
+		autoplay?: boolean;
+		loop?: boolean;
+		start?: Maybe<number>;
+		options?: VimeoEmbedOptions;
+	}
+
+	let {
+		url,
+		title = null,
+		muted = false,
+		autoplay = true,
+		loop = false,
+		start = null,
+		options = VIMEO_DEFAULTS
+	}: Props = $props();
 
 	const api = getVideoEmbedContext();
 	const { playing, preconnect } = api || {};
@@ -46,8 +58,8 @@
 		? `https://player.vimeo.com/video/${videoId}?${paramString}${start ? `#t=${start}s` : ''}`
 		: null;
 
-	$: _preconnect = $preconnect ?? false;
-	$: _playing = $playing ?? true;
+	let _preconnect = $derived($preconnect ?? false);
+	let _playing = $derived($playing ?? true);
 </script>
 
 <svelte:head>
@@ -64,5 +76,5 @@
 		frameborder="0"
 		allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
 		allowfullscreen
-	/>
+	></iframe>
 {/if}

--- a/packages/components/video-embed/src/lib/VimeoEmbed.svelte
+++ b/packages/components/video-embed/src/lib/VimeoEmbed.svelte
@@ -1,11 +1,26 @@
 <script module lang="ts">
 	export type VimeoEmbedOptions = {
 		h?: string;
-		title?: boolean | string; // show title
-		byline?: boolean | string; // show 'by' line
-		portrait?: boolean | string; // show portrait
-		autopause?: boolean | string; // mandatory if you have multiple vimeo embeds on the same page on autoplay
-		background?: boolean; // background mode (no controls, no nothing)
+		/**
+		 * Show the title.
+		 */
+		title?: boolean | string;
+		/**
+		 * Show the 'by' line.
+		 */
+		byline?: boolean | string;
+		/**
+		 * Show the portrait.
+		 */
+		portrait?: boolean | string;
+		/**
+		 * Autopause. Mandatory if you have multiple vimeo embeds on the same page on autoplay
+		 */
+		autopause?: boolean | string;
+		/**
+		 * Background mode (no controls, no nothing).
+		 */
+		background?: boolean;
 	};
 
 	export const VIMEO_DEFAULTS: VimeoEmbedOptions = {
@@ -18,7 +33,7 @@
 </script>
 
 <script lang="ts">
-	import { getVideoEmbedContext } from './EmbedGroup.svelte';
+	import { videoEmbedContext } from './videoEmbed.svelte.js';
 	import { objectToQueryString } from '@288-toolkit/strings';
 	import type { Maybe } from '@288-toolkit/types';
 
@@ -42,8 +57,7 @@
 		options = VIMEO_DEFAULTS
 	}: Props = $props();
 
-	const api = getVideoEmbedContext();
-	const { playing, preconnect } = api || {};
+	const api = videoEmbedContext.get();
 
 	const videoParams = url ? new URL(url).pathname.replace('/', '') : '';
 	const [videoId, unlistedHash] = videoParams.split('/');
@@ -58,8 +72,8 @@
 		? `https://player.vimeo.com/video/${videoId}?${paramString}${start ? `#t=${start}s` : ''}`
 		: null;
 
-	let _preconnect = $derived($preconnect ?? false);
-	let _playing = $derived($playing ?? true);
+	let _preconnect = $derived(api?.preconnect ?? false);
+	let _playing = $derived(api?.playing ?? true);
 </script>
 
 <svelte:head>

--- a/packages/components/video-embed/src/lib/VimeoEmbed.svelte
+++ b/packages/components/video-embed/src/lib/VimeoEmbed.svelte
@@ -38,7 +38,7 @@
 	import type { Maybe } from '@288-toolkit/types';
 
 	interface Props {
-		url: Maybe<string>;
+		url?: Maybe<string>;
 		title?: Maybe<string>;
 		muted?: boolean;
 		autoplay?: boolean;
@@ -47,8 +47,10 @@
 		options?: VimeoEmbedOptions;
 	}
 
+	const api = videoEmbedContext.get();
+
 	let {
-		url,
+		url = api?.url,
 		title = null,
 		muted = false,
 		autoplay = true,
@@ -56,8 +58,6 @@
 		start = null,
 		options = VIMEO_DEFAULTS
 	}: Props = $props();
-
-	const api = videoEmbedContext.get();
 
 	const videoParams = url ? new URL(url).pathname.replace('/', '') : '';
 	const [videoId, unlistedHash] = videoParams.split('/');

--- a/packages/components/video-embed/src/lib/YoutubeEmbed.svelte
+++ b/packages/components/video-embed/src/lib/YoutubeEmbed.svelte
@@ -1,6 +1,8 @@
 <script module lang="ts">
+	/**
+	 * See https://developers.google.com/youtube/player_parameters#Parameters for more information.
+	 */
 	export type YoutubeEmbedOptions = {
-		/** https://developers.google.com/youtube/player_parameters#Parameters */
 		cc_lang_pref?: string;
 		cc_load_policy?: boolean;
 		color?: 'red' | 'white';
@@ -27,7 +29,7 @@
 <script lang="ts">
 	/** Based on https://github.com/paulirish/lite-youtube-embed */
 	import { getYoutubeId } from './youtube.js';
-	import { getVideoEmbedContext } from './EmbedGroup.svelte';
+	import { videoEmbedContext } from './videoEmbed.svelte.js';
 	import type { Maybe } from '@288-toolkit/types';
 	import { objectToQueryString } from '@288-toolkit/strings';
 
@@ -54,8 +56,7 @@
 	const videoId = url ? getYoutubeId(url) : null;
 	const playlist = loop ? videoId : options?.playlist || null;
 
-	const api = getVideoEmbedContext();
-	const { playing, preconnect } = api || {};
+	const api = videoEmbedContext.get();
 
 	const paramString = objectToQueryString({
 		autoplay: autoplay ? '1' : autoplay,
@@ -71,8 +72,8 @@
 		? null
 		: `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?${paramString}`;
 
-	let _preconnect = $derived($preconnect ?? false);
-	let _playing = $derived($playing ?? true);
+	let _preconnect = $derived(api?.preconnect ?? false);
+	let _playing = $derived(api?.playing ?? true);
 </script>
 
 <svelte:head>

--- a/packages/components/video-embed/src/lib/YoutubeEmbed.svelte
+++ b/packages/components/video-embed/src/lib/YoutubeEmbed.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
 	export type YoutubeEmbedOptions = {
 		/** https://developers.google.com/youtube/player_parameters#Parameters */
 		cc_lang_pref?: string;
@@ -31,13 +31,25 @@
 	import type { Maybe } from '@288-toolkit/types';
 	import { objectToQueryString } from '@288-toolkit/strings';
 
-	export let url: Maybe<string>;
-	export let title: Maybe<string> = null;
-	export let muted = false;
-	export let autoplay = true;
-	export let loop = false;
-	export let start: Maybe<number> = null;
-	export let options: Maybe<YoutubeEmbedOptions> = YOUTUBE_DEFAULTS;
+	interface Props {
+		url: Maybe<string>;
+		title?: Maybe<string>;
+		muted?: boolean;
+		autoplay?: boolean;
+		loop?: boolean;
+		start?: Maybe<number>;
+		options?: Maybe<YoutubeEmbedOptions>;
+	}
+
+	let {
+		url,
+		title = null,
+		muted = false,
+		autoplay = true,
+		loop = false,
+		start = null,
+		options = YOUTUBE_DEFAULTS
+	}: Props = $props();
 
 	const videoId = url ? getYoutubeId(url) : null;
 	const playlist = loop ? videoId : options?.playlist || null;
@@ -59,8 +71,8 @@
 		? null
 		: `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?${paramString}`;
 
-	$: _preconnect = $preconnect ?? false;
-	$: _playing = $playing ?? true;
+	let _preconnect = $derived($preconnect ?? false);
+	let _playing = $derived($playing ?? true);
 </script>
 
 <svelte:head>
@@ -78,5 +90,5 @@
 		frameborder="0"
 		allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
 		allowfullscreen
-	/>
+	></iframe>
 {/if}

--- a/packages/components/video-embed/src/lib/YoutubeEmbed.svelte
+++ b/packages/components/video-embed/src/lib/YoutubeEmbed.svelte
@@ -34,7 +34,7 @@
 	import { objectToQueryString } from '@288-toolkit/strings';
 
 	interface Props {
-		url: Maybe<string>;
+		url?: Maybe<string>;
 		title?: Maybe<string>;
 		muted?: boolean;
 		autoplay?: boolean;
@@ -43,8 +43,10 @@
 		options?: Maybe<YoutubeEmbedOptions>;
 	}
 
+	const api = videoEmbedContext.get();
+
 	let {
-		url,
+		url = api?.url,
 		title = null,
 		muted = false,
 		autoplay = true,
@@ -55,8 +57,6 @@
 
 	const videoId = url ? getYoutubeId(url) : null;
 	const playlist = loop ? videoId : options?.playlist || null;
-
-	const api = videoEmbedContext.get();
 
 	const paramString = objectToQueryString({
 		autoplay: autoplay ? '1' : autoplay,

--- a/packages/components/video-embed/src/lib/exports.ts
+++ b/packages/components/video-embed/src/lib/exports.ts
@@ -1,0 +1,6 @@
+export { default as Root } from './EmbedGroup.svelte';
+export { default as PlayButton } from './EmbedPlayButton.svelte';
+export { default as ProviderSelector } from './EmbedSelector.svelte';
+export { default as Thumbnail } from './EmbedThumbnail.svelte';
+export { default as Vimeo } from './VimeoEmbed.svelte';
+export { default as Youtube } from './YoutubeEmbed.svelte';

--- a/packages/components/video-embed/src/lib/index.ts
+++ b/packages/components/video-embed/src/lib/index.ts
@@ -1,15 +1,27 @@
-export * from './EmbedGroup.svelte';
-export { default as EmbedGroup } from './EmbedGroup.svelte';
-export * from './EmbedPlayButton.svelte';
-export { default as EmbedPlayButton } from './EmbedPlayButton.svelte';
-export * from './EmbedSelector.svelte';
-export { default as EmbedSelector } from './EmbedSelector.svelte';
-export * from './EmbedThumbnail.svelte';
-export { default as EmbedThumbnail } from './EmbedThumbnail.svelte';
 export * from './VimeoEmbed.svelte';
-export { default as VimeoEmbed } from './VimeoEmbed.svelte';
 export * from './YoutubeEmbed.svelte';
-export { default as YoutubeEmbed } from './YoutubeEmbed.svelte';
+export * as VideoEmbed from './exports.js';
 export * from './vimeo.js';
 export * from './vimeoThumbnailHandler.js';
 export * from './youtube.js';
+
+/**
+ * @deprecated Use `VideoEmbed.Root` instead.
+ */
+export { default as EmbedPlayButton } from './EmbedPlayButton.svelte';
+/**
+ * @deprecated Use `VideoEmbed.ProviderSelector` instead.
+ */
+export { default as EmbedSelector } from './EmbedSelector.svelte';
+/**
+ * @deprecated Use `VideoEmbed.Thumbnail` instead.
+ */
+export { default as EmbedThumbnail } from './EmbedThumbnail.svelte';
+/**
+ * @deprecated Use `VideoEmbed.Vimeo` instead.
+ */
+export { default as VimeoEmbed } from './VimeoEmbed.svelte';
+/**
+ * @deprecated Use `VideoEmbed.Youtube` instead.
+ */
+export { default as YoutubeEmbed } from './YoutubeEmbed.svelte';

--- a/packages/components/video-embed/src/lib/index.ts
+++ b/packages/components/video-embed/src/lib/index.ts
@@ -1,6 +1,7 @@
 export * from './VimeoEmbed.svelte';
 export * from './YoutubeEmbed.svelte';
 export * as VideoEmbed from './exports.js';
+export * from './useVideoEmbed.js';
 export * from './vimeo.js';
 export * from './vimeoThumbnailHandler.js';
 export * from './youtube.js';

--- a/packages/components/video-embed/src/lib/translations/en.ts
+++ b/packages/components/video-embed/src/lib/translations/en.ts
@@ -1,5 +1,0 @@
-export const en = {
-	play: 'Play'
-};
-
-export type VideoEmbedTranslations = typeof en;

--- a/packages/components/video-embed/src/lib/translations/fr.ts
+++ b/packages/components/video-embed/src/lib/translations/fr.ts
@@ -1,5 +1,0 @@
-import type { VideoEmbedTranslations } from './en.js';
-
-export const fr: VideoEmbedTranslations = {
-	play: 'Jouer'
-};

--- a/packages/components/video-embed/src/lib/translations/index.ts
+++ b/packages/components/video-embed/src/lib/translations/index.ts
@@ -1,6 +1,0 @@
-import { createTranslate } from '@288-toolkit/i18n';
-import type { VideoEmbedTranslations } from './en.js';
-
-export const key = 'video-embed';
-
-export const t = createTranslate<VideoEmbedTranslations>(key);

--- a/packages/components/video-embed/src/lib/translations/loader.ts
+++ b/packages/components/video-embed/src/lib/translations/loader.ts
@@ -1,9 +1,0 @@
-import { key } from './index.js';
-
-export const videoEmbed = {
-	key,
-	loaders: {
-		en: () => import('./en.js'),
-		fr: () => import('./fr.js')
-	}
-} as const;

--- a/packages/components/video-embed/src/lib/useVideoEmbed.ts
+++ b/packages/components/video-embed/src/lib/useVideoEmbed.ts
@@ -1,0 +1,5 @@
+import { videoEmbedContext } from './videoEmbed.svelte.js';
+
+export const useVideoEmbed = () => {
+	return videoEmbedContext.get();
+};

--- a/packages/components/video-embed/src/lib/videoEmbed.svelte.ts
+++ b/packages/components/video-embed/src/lib/videoEmbed.svelte.ts
@@ -1,37 +1,49 @@
-import { Maybe } from '@288-toolkit/types';
+import type { Maybe } from '@288-toolkit/types';
 import { Context } from 'runed';
 
 export class VideoEmbedApi {
-	/**
-	 * Indicates if the video is currently playing
-	 */
-	playing = $state(false);
-	/**
-	 * Indicates if preconnect has been requested
-	 */
-	preconnect = $state(false);
-	/**
-	 * The URL of the video
-	 */
-	url = $state<Maybe<string>>(null);
+	#playing = $state(false);
+	#preconnect = $state(false);
+	#url = $state<Maybe<string> | undefined>(undefined);
 
-	constructor(url: Maybe<string>) {
-		this.url = url;
+	constructor(url?: Maybe<string>) {
+		this.#url = url;
 	}
 
 	/**
 	 * Request preconnect
 	 */
 	requestPreconnect = () => {
-		this.preconnect = true;
+		this.#preconnect = true;
 	};
 
 	/**
 	 * Play the video
 	 */
 	play = () => {
-		this.playing = true;
+		this.#playing = true;
 	};
+
+	/**
+	 * The URL of the video
+	 */
+	get url() {
+		return this.#url;
+	}
+
+	/**
+	 * Indicates if preconnect has been requested
+	 */
+	get playing() {
+		return this.#playing;
+	}
+
+	/**
+	 * Indicates if the video is currently playing
+	 */
+	get preconnect() {
+		return this.#preconnect;
+	}
 }
 
 export const videoEmbedContext = new Context<VideoEmbedApi>('video-embed-context');

--- a/packages/components/video-embed/src/lib/videoEmbed.svelte.ts
+++ b/packages/components/video-embed/src/lib/videoEmbed.svelte.ts
@@ -1,0 +1,37 @@
+import { Maybe } from '@288-toolkit/types';
+import { Context } from 'runed';
+
+export class VideoEmbedApi {
+	/**
+	 * Indicates if the video is currently playing
+	 */
+	playing = $state(false);
+	/**
+	 * Indicates if preconnect has been requested
+	 */
+	preconnect = $state(false);
+	/**
+	 * The URL of the video
+	 */
+	url = $state<Maybe<string>>(null);
+
+	constructor(url: Maybe<string>) {
+		this.url = url;
+	}
+
+	/**
+	 * Request preconnect
+	 */
+	requestPreconnect = () => {
+		this.preconnect = true;
+	};
+
+	/**
+	 * Play the video
+	 */
+	play = () => {
+		this.playing = true;
+	};
+}
+
+export const videoEmbedContext = new Context<VideoEmbedApi>('video-embed-context');

--- a/packages/components/video-embed/svelte.config.js
+++ b/packages/components/video-embed/svelte.config.js
@@ -1,9 +1,6 @@
-import preprocess from 'svelte-preprocess';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 export default {
-	compilerOptions: {
-		accessors: !!process.env.VITEST
-	},
-	preprocess: [preprocess()]
+	preprocess: [vitePreprocess()]
 };

--- a/packages/components/video-embed/test/VimeoEmbed.spec.ts
+++ b/packages/components/video-embed/test/VimeoEmbed.spec.ts
@@ -4,14 +4,13 @@ import { expect, test } from 'vitest';
 
 const baseScript = `
 <script lang="ts">
-import { setContext } from 'svelte';
-import { readable } from 'svelte/store';
-import VimeoEmbed from '$lib/VimeoEmbed.svelte';
+	import VimeoEmbed from '$lib/VimeoEmbed.svelte';
+	import { VideoEmbedApi, videoEmbedContext } from '$lib/videoEmbed.svelte.js';
 
-setContext('__videoEmbed__', {
-	playing: readable(true),
-	preconnect: readable(true)
-});
+	const api = videoEmbedContext.set(new VideoEmbedApi());
+
+	api.requestPreconnect();
+	api.play();
 </script>
 
 `;

--- a/packages/components/video-embed/test/VimeoEmbed.spec.ts
+++ b/packages/components/video-embed/test/VimeoEmbed.spec.ts
@@ -1,5 +1,5 @@
 import { svelte } from '@288-toolkit/vite-plugin-svelte-inline-component';
-import { render } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte/svelte5';
 import { expect, test } from 'vitest';
 
 const baseScript = `

--- a/packages/components/video-embed/test/YoutubeEmbed.spec.ts
+++ b/packages/components/video-embed/test/YoutubeEmbed.spec.ts
@@ -4,14 +4,13 @@ import { expect, test } from 'vitest';
 
 const baseScript = `
 <script lang="ts">
-import { setContext } from 'svelte';
-import { readable } from 'svelte/store';
-import YoutubeEmbed from '$lib/YoutubeEmbed.svelte';
+	import YoutubeEmbed from '$lib/YoutubeEmbed.svelte';
+	import { VideoEmbedApi, videoEmbedContext } from '$lib/videoEmbed.svelte.js';
 
-setContext('__videoEmbed__', {
-	playing: readable(true),
-	preconnect: readable(true)
-});
+	const api = videoEmbedContext.set(new VideoEmbedApi());
+
+	api.requestPreconnect();
+	api.play();
 </script>
 
 `;

--- a/packages/components/video-embed/test/YoutubeEmbed.spec.ts
+++ b/packages/components/video-embed/test/YoutubeEmbed.spec.ts
@@ -1,5 +1,5 @@
 import { svelte } from '@288-toolkit/vite-plugin-svelte-inline-component';
-import { render } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte/svelte5';
 import { expect, test } from 'vitest';
 
 const baseScript = `

--- a/packages/components/video-embed/test/setup.ts
+++ b/packages/components/video-embed/test/setup.ts
@@ -1,1 +1,2 @@
+import '@testing-library/jest-dom/vitest';
 import '../../../../shared/test/mocks/sveltekit';

--- a/packages/components/video-embed/vitest.config.js
+++ b/packages/components/video-embed/vitest.config.js
@@ -1,5 +1,6 @@
 import { svelteInlineComponent } from '@288-toolkit/vite-plugin-svelte-inline-component';
 import { sveltekit } from '@sveltejs/kit/vite';
+import { svelteTesting } from '@testing-library/svelte/vite';
 import { defineProject, mergeConfig } from 'vitest/config';
 import baseConfig from '../../../vitest.shared';
 
@@ -7,9 +8,8 @@ export default mergeConfig(
 	baseConfig,
 	defineProject({
 		test: {
-			setupFiles: ['./test/setup.ts'],
-			alias: [{ find: /^svelte$/, replacement: 'svelte/internal' }]
+			setupFiles: ['./test/setup.ts']
 		},
-		plugins: [sveltekit(), svelteInlineComponent()]
+		plugins: [sveltekit(), svelteTesting(), svelteInlineComponent()]
 	})
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1154,6 +1154,9 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/estree@1.0.6':
+    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1367,6 +1370,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.1:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
@@ -1454,6 +1462,10 @@ packages:
 
   axobject-query@3.2.4:
     resolution: {integrity: sha512-aPTElBrbifBU1krmZxGZOlBkslORe7Ll7+BDnI50Wy4LgOt69luMgevkDfTq1O/ZgprooPCtWpjCwKSZw/iZ4A==}
+    engines: {node: '>= 0.4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
   axobject-query@4.1.0:
@@ -4175,6 +4187,24 @@ snapshots:
       tiny-glob: 0.2.9
       vite: 5.2.11(@types/node@20.12.7)
 
+  '@sveltejs/kit@2.5.5(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.2.10)(vite@5.2.11(@types/node@20.12.7)))(svelte@5.2.10)(vite@5.2.11(@types/node@20.12.7))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@5.2.10)(vite@5.2.11(@types/node@20.12.7))
+      '@types/cookie': 0.6.0
+      cookie: 0.6.0
+      devalue: 4.3.2
+      esm-env: 1.0.0
+      import-meta-resolve: 4.0.0
+      kleur: 4.1.5
+      magic-string: 0.30.9
+      mrmime: 2.0.0
+      sade: 1.8.1
+      set-cookie-parser: 2.6.0
+      sirv: 2.0.4
+      svelte: 5.2.10
+      tiny-glob: 0.2.9
+      vite: 5.2.11(@types/node@20.12.7)
+
   '@sveltejs/kit@2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
@@ -4372,6 +4402,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.6
       '@types/json-schema': 7.0.15
+
+  '@types/estree@1.0.6': {}
 
   '@types/estree@1.0.6': {}
 
@@ -4656,6 +4688,8 @@ snapshots:
 
   acorn@8.14.0: {}
 
+  acorn@8.14.0: {}
+
   agent-base@7.1.1:
     dependencies:
       debug: 4.3.7
@@ -4750,6 +4784,8 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   axobject-query@3.2.4: {}
+
+  axobject-query@4.1.0: {}
 
   axobject-query@4.1.0: {}
 
@@ -6611,7 +6647,7 @@ snapshots:
       postcss: 8.4.49
       postcss-scss: 4.0.9(postcss@8.4.49)
     optionalDependencies:
-      svelte: 4.2.17
+      svelte: 5.2.10
 
   svelte-eslint-parser@0.43.0(svelte@5.17.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
         specifier: 4.x || 5.x
         version: 4.0.0
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.6.3
       svelte-preprocess:
         specifier: 5.1.4
         version: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
@@ -1126,6 +1129,10 @@ packages:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
 
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@testing-library/svelte@5.1.0':
     resolution: {integrity: sha512-8GW+rBR72U7Qql0Glxl4CtVTr6GPotYf/MB7MamIH6ZpV45i7IJIOm3oHWH4Wr6ZULdUs37F9recegQygLbC0g==}
     engines: {node: '>= 10'}
@@ -1536,6 +1543,10 @@ packages:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
 
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1621,6 +1632,9 @@ packages:
   css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -4859,6 +4873,11 @@ snapshots:
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
 
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4954,6 +4973,8 @@ snapshots:
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,9 +323,6 @@ importers:
       '@288-toolkit/html-elements':
         specifier: workspace:*
         version: link:../html-elements
-      '@288-toolkit/i18n':
-        specifier: workspace:*
-        version: link:../../i18n
       '@288-toolkit/strings':
         specifier: workspace:*
         version: link:../../strings
@@ -337,7 +334,7 @@ importers:
         version: link:../../vite-plugin-svelte-inline-component
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.17.2)(vite@5.2.11(@types/node@20.12.7)))(svelte@5.17.2)(vite@5.2.11(@types/node@20.12.7))
       '@testing-library/svelte':
         specifier: ^5.1.0
         version: 5.1.0(svelte@5.17.2)(vite@5.2.11(@types/node@20.12.7))(vitest@packages+components+video-embed+@testing-library+jest-dom+vitest)
@@ -351,9 +348,6 @@ importers:
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
-      svelte-preprocess:
-        specifier: ^6.0.0
-        version: 6.0.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.17.2)(typescript@5.4.5)
       vitest:
         specifier: link:@testing-library/jest-dom/vitest
         version: link:@testing-library/jest-dom/vitest
@@ -3211,43 +3205,6 @@ packages:
       sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
       svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
       typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-
-  svelte-preprocess@6.0.3:
-    resolution: {integrity: sha512-PLG2k05qHdhmRG7zR/dyo5qKvakhm8IJ+hD2eFRQmMLHp7X3eJnjeupUtvuRpbNiF31RjVw45W+abDwHEmP5OA==}
-    engines: {node: '>= 18.0.0'}
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      postcss: ^7 || ^8
-      postcss-load-config: '>=3'
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: '>=0.55'
-      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.100 || ^5.0.0
-      typescript: ^5.0.0
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -6790,14 +6747,6 @@ snapshots:
       magic-string: 0.30.14
       sorcery: 0.11.1
       strip-indent: 3.0.0
-      svelte: 5.17.2
-    optionalDependencies:
-      postcss: 8.4.49
-      postcss-load-config: 3.1.4(postcss@8.4.49)
-      typescript: 5.4.5
-
-  svelte-preprocess@6.0.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.17.2)(typescript@5.4.5):
-    dependencies:
       svelte: 5.17.2
     optionalDependencies:
       postcss: 8.4.49

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,23 +194,23 @@ importers:
         version: link:../../vite-plugin-svelte-inline-component
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
       esm-env:
         specifier: 1.0.0
         version: 1.0.0
       svelte:
         specifier: 4.x || 5.x
-        version: 4.0.0
+        version: 4.2.17
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.0.0
-        version: 10.0.0
+        version: 10.4.0
       '@testing-library/svelte':
         specifier: ^5.1.0
-        version: 5.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))(vitest@2.1.6(@types/node@20.12.7)(jsdom@24.0.0))
+        version: 5.2.6(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))(vitest@2.1.6(@types/node@20.12.7)(jsdom@24.0.0))
       svelte-preprocess:
         specifier: 5.1.4
-        version: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
+        version: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.17)(typescript@5.4.5)
 
   packages/components/html-elements:
     dependencies:
@@ -329,9 +329,6 @@ importers:
       '@288-toolkit/strings':
         specifier: workspace:*
         version: link:../../strings
-      '@288-toolkit/typed-context':
-        specifier: workspace:*
-        version: link:../../typed-context
       '@288-toolkit/types':
         specifier: workspace:*
         version: link:../../types
@@ -343,17 +340,23 @@ importers:
         version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       '@testing-library/svelte':
         specifier: ^5.1.0
-        version: 5.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))(vitest@2.1.6(@types/node@20.12.7)(jsdom@24.0.0))
+        version: 5.1.0(svelte@5.17.2)(vite@5.2.11(@types/node@20.12.7))(vitest@packages+components+video-embed+@testing-library+jest-dom+vitest)
+      runed:
+        specifier: ^0.23.0
+        version: 0.23.0(svelte@5.17.2)
       svelte:
-        specifier: 4.x || 5.x
-        version: 4.0.0
+        specifier: 5.x
+        version: 5.17.2
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
       svelte-preprocess:
-        specifier: 5.1.4
-        version: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
+        specifier: ^6.0.0
+        version: 6.0.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.17.2)(typescript@5.4.5)
+      vitest:
+        specifier: link:@testing-library/jest-dom/vitest
+        version: link:@testing-library/jest-dom/vitest
 
   packages/css: {}
 
@@ -636,6 +639,9 @@ importers:
         version: 5.2.11(@types/node@20.12.7)
 
 packages:
+
+  '@adobe/css-tools@4.4.1':
+    resolution: {integrity: sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1121,8 +1127,8 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
 
-  '@testing-library/dom@10.0.0':
-    resolution: {integrity: sha512-PmJPnogldqoVFf+EwbHvbBJ98MmqASV8kLrBYgsDNxQcFMeIS7JFL48sfyXvuMtgmWO/wMhh25odr+8VhDmn4g==}
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
 
   '@testing-library/dom@9.3.4':
@@ -1146,6 +1152,19 @@ packages:
       vitest:
         optional: true
 
+  '@testing-library/svelte@5.2.6':
+    resolution: {integrity: sha512-1Y8cEg/BtV4J6g9irkY0ksz+ueDFYLiikjTLiqvQPkOUeDzR4gg2zECBf8yrOrCy3e2TAOYMcaysFa0bQMyk1w==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: '*'
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
+
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
@@ -1157,9 +1176,6 @@ packages:
 
   '@types/eslint@8.56.10':
     resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
-
-  '@types/estree@1.0.6':
-    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1377,11 +1393,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.14.0:
-    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   agent-base@7.1.1:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
@@ -1469,10 +1480,6 @@ packages:
 
   axobject-query@3.2.4:
     resolution: {integrity: sha512-aPTElBrbifBU1krmZxGZOlBkslORe7Ll7+BDnI50Wy4LgOt69luMgevkDfTq1O/ZgprooPCtWpjCwKSZw/iZ4A==}
-    engines: {node: '>= 0.4'}
-
-  axobject-query@4.1.0:
-    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
   axobject-query@4.1.0:
@@ -1751,6 +1758,9 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   electron-to-chromium@1.5.67:
     resolution: {integrity: sha512-nz88NNBsD7kQSAGGJyp8hS6xSPtWwqNogA0mjtc2nUYeEf3nURK9qpV18TuBdDmEDgVWotS8Wkzf+V52dSQ/LQ==}
@@ -2946,6 +2956,11 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  runed@0.23.0:
+    resolution: {integrity: sha512-WrZcFneb3CkFvujgss6WIvKmlSUvX2z8nYsH+zrd8eo55zO6nkEJ6fRL2QZW+2lAD4DVvAK/8x0dotIRVrnPJQ==}
+    peerDependencies:
+      svelte: ^5.7.0
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -3196,6 +3211,43 @@ packages:
       sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
       svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
       typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+
+  svelte-preprocess@6.0.3:
+    resolution: {integrity: sha512-PLG2k05qHdhmRG7zR/dyo5qKvakhm8IJ+hD2eFRQmMLHp7X3eJnjeupUtvuRpbNiF31RjVw45W+abDwHEmP5OA==}
+    engines: {node: '>= 18.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      postcss: ^7 || ^8
+      postcss-load-config: '>=3'
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: '>=0.55'
+      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.100 || ^5.0.0
+      typescript: ^5.0.0
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -3699,6 +3751,8 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.1': {}
+
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
@@ -4201,24 +4255,6 @@ snapshots:
       tiny-glob: 0.2.9
       vite: 5.2.11(@types/node@20.12.7)
 
-  '@sveltejs/kit@2.5.5(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.2.10)(vite@5.2.11(@types/node@20.12.7)))(svelte@5.2.10)(vite@5.2.11(@types/node@20.12.7))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@5.2.10)(vite@5.2.11(@types/node@20.12.7))
-      '@types/cookie': 0.6.0
-      cookie: 0.6.0
-      devalue: 4.3.2
-      esm-env: 1.0.0
-      import-meta-resolve: 4.0.0
-      kleur: 4.1.5
-      magic-string: 0.30.9
-      mrmime: 2.0.0
-      sade: 1.8.1
-      set-cookie-parser: 2.6.0
-      sirv: 2.0.4
-      svelte: 5.2.10
-      tiny-glob: 0.2.9
-      vite: 5.2.11(@types/node@20.12.7)
-
   '@sveltejs/kit@2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
@@ -4376,7 +4412,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@testing-library/dom@10.0.0':
+  '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/runtime': 7.26.0
@@ -4398,10 +4434,36 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.1
+      aria-query: 5.3.2
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
+
   '@testing-library/svelte@5.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))(vitest@2.1.6(@types/node@20.12.7)(jsdom@24.0.0))':
     dependencies:
       '@testing-library/dom': 9.3.4
       svelte: 4.0.0
+    optionalDependencies:
+      vite: 5.2.11(@types/node@20.12.7)
+      vitest: 2.1.6(@types/node@20.12.7)(jsdom@24.0.0)
+
+  '@testing-library/svelte@5.1.0(svelte@5.17.2)(vite@5.2.11(@types/node@20.12.7))(vitest@packages+components+video-embed+@testing-library+jest-dom+vitest)':
+    dependencies:
+      '@testing-library/dom': 9.3.4
+      svelte: 5.17.2
+    optionalDependencies:
+      vite: 5.2.11(@types/node@20.12.7)
+      vitest: link:packages/components/video-embed/@testing-library/jest-dom/vitest
+
+  '@testing-library/svelte@5.2.6(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))(vitest@2.1.6(@types/node@20.12.7)(jsdom@24.0.0))':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      svelte: 4.2.17
     optionalDependencies:
       vite: 5.2.11(@types/node@20.12.7)
       vitest: 2.1.6(@types/node@20.12.7)(jsdom@24.0.0)
@@ -4416,8 +4478,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.6
       '@types/json-schema': 7.0.15
-
-  '@types/estree@1.0.6': {}
 
   '@types/estree@1.0.6': {}
 
@@ -4702,8 +4762,6 @@ snapshots:
 
   acorn@8.14.0: {}
 
-  acorn@8.14.0: {}
-
   agent-base@7.1.1:
     dependencies:
       debug: 4.3.7
@@ -4798,8 +4856,6 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   axobject-query@3.2.4: {}
-
-  axobject-query@4.1.0: {}
 
   axobject-query@4.1.0: {}
 
@@ -5095,6 +5151,8 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   electron-to-chromium@1.5.67: {}
 
@@ -6396,6 +6454,11 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  runed@0.23.0(svelte@5.17.2):
+    dependencies:
+      esm-env: 1.0.0
+      svelte: 5.17.2
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -6668,7 +6731,7 @@ snapshots:
       postcss: 8.4.49
       postcss-scss: 4.0.9(postcss@8.4.49)
     optionalDependencies:
-      svelte: 5.2.10
+      svelte: 4.2.17
 
   svelte-eslint-parser@0.43.0(svelte@5.17.2):
     dependencies:
@@ -6727,6 +6790,14 @@ snapshots:
       magic-string: 0.30.14
       sorcery: 0.11.1
       strip-indent: 3.0.0
+      svelte: 5.17.2
+    optionalDependencies:
+      postcss: 8.4.49
+      postcss-load-config: 3.1.4(postcss@8.4.49)
+      typescript: 5.4.5
+
+  svelte-preprocess@6.0.3(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@5.17.2)(typescript@5.4.5):
+    dependencies:
       svelte: 5.17.2
     optionalDependencies:
       postcss: 8.4.49


### PR DESCRIPTION
### `html-elements` 

The components have been migrated to Svelte 5, not much to except that the rest props on `video` element causing problems with the `autoplay` attribute has been fixed by this.

### `video-embed`

- Components now use Svelte 5 syntax
- The context logic has been abstracted to a reactive class in `videoEmbedApi.svelte.ts`.
- Removed dependency on `@288-toolkit/typed-context` package in favor of [runed's `Context` api](https://runed.dev/docs/utilities/context).
- Added the `useVideoEmbed` function to get the API from context.
- I decided to remove the translations since they only had one property. I instead opted for making the `EmbedPlayButton` `label` prop required to make sure the button remains accessible to screen readers. In my opinion, this change makes it simpler to use the package. In projects, we pass props to components way more often than we load package translations.
- The `YoutubeEmbed` and `VimeoEmbed` components now grab the url from context if available.
- The individual component exports have been deprecated in favor of exporting a single `VideoEmbed` component to be used with dot notation. This change aligns with `bits-ui` APIs and simplifies usage.
- Adjusted the test to reflect the changes.
- Adjusted the documentation.
