### PR TITLE
(feat) Add new parseDateTime api

### DIFF
--- a/.changeset/tricky-maps-guess.md
+++ b/.changeset/tricky-maps-guess.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/dates': minor
+---
+
+Add new parseDateTime api

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"lint:fix": "npm run lint -- --fix",
 		"lc": "npm run lint && npm run check",
 		"lc:watch": "npm run lint && npm run check -- --watch",
+		"cs": "pnpm changeset",
 		"version": "pnpm changeset version",
 		"ci:version": "pnpm changeset version",
 		"ci:publish": "pnpm --filter \"@288-toolkit/*\" publish -r --no-git-checks --access public"

--- a/packages/dates/src/index.ts
+++ b/packages/dates/src/index.ts
@@ -1,2 +1,3 @@
 export * from './parseLocalDate.js';
+export * from './parseDateTime.js';
 export * from './today.js';

--- a/packages/dates/src/parseDateTime.ts
+++ b/packages/dates/src/parseDateTime.ts
@@ -1,0 +1,28 @@
+/**
+ * Converts a string into a Date object. If the string is a Date object, it
+ * returns a new Date object with the same time. If the string is not a valid date, it returns null.
+ *
+ * @param date The string or Date object to parse.
+ * @returns A Date object or null if the string is not a valid date.
+ */
+export const parseDateTime = (date: string | Date) => {
+	if (!date) {
+		return null;
+	}
+
+	if (date instanceof Date) {
+		if (isNaN(date.getTime())) {
+			return null;
+		}
+
+		return new Date(date);
+	}
+
+	const parsedDate = new Date(date);
+
+	if (isNaN(parsedDate.getTime())) {
+		return null;
+	}
+
+	return parsedDate;
+};

--- a/packages/dates/test/parseDateTime.spec.ts
+++ b/packages/dates/test/parseDateTime.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { parseDateTime } from '../src/parseDateTime';
+
+describe('parseDateTime()', () => {
+	test('should return null if the string is empty', () => {
+		expect(parseDateTime('')).toBeNull();
+	});
+
+	test('should return the same date if the input is a Date object', () => {
+		const date = new Date();
+		expect(parseDateTime(date)).toEqual(date);
+	});
+
+	test('should return a new Date object with the same time if the input is a string', () => {
+		const date = new Date('2023-01-01T00:00:00Z');
+		expect(parseDateTime('2023-01-01T00:00:00Z')).toEqual(date);
+	});
+
+	test('should return a new Date object with the same localized time if the input is a string', () => {
+		const date = new Date('2023-01-01T00:00:00-0200');
+		expect(parseDateTime('2023-01-01T00:00:00-0200')).toEqual(date);
+	});
+
+	test('should return null if the string is not a valid date', () => {
+		expect(parseDateTime('sasasa')).toBeNull();
+		expect(parseDateTime(null as unknown as string)).toBeNull();
+	});
+
+	test('should return null if the date is not a valid date', () => {
+		expect(parseDateTime(new Date('sasasa'))).toBeNull();
+	});
+});


### PR DESCRIPTION
This api allows us to make sure invalid dates won't throw when formatting them.

new Date('sasa') works, but will either return 'Invalid Date' or throw when formatting it.