### PR TITLE
(feat) Make createEntryUrlBuilder() Craft 5 compatible

### DIFF
--- a/.changeset/blue-lies-marry.md
+++ b/.changeset/blue-lies-marry.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/url': major
+---
+
+Make createEntryUrlBuilder() Craft 5 compatible

--- a/.changeset/pink-seahorses-draw.md
+++ b/.changeset/pink-seahorses-draw.md
@@ -1,5 +1,5 @@
 ---
-'@288-toolkit/url': major
+'@288-toolkit/url': minor
 ---
 
 Make createEntryUrlBuilder() Craft 5 compatible

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,5 +27,7 @@ jobs:
               run: pnpm install
             - name: sync
               run: pnpm sync
+            - name: build
+              run: pnpm build
             - name: run tests
               run: pnpm test

--- a/packages/components/video-embed/package.json
+++ b/packages/components/video-embed/package.json
@@ -41,6 +41,7 @@
 		"@288-toolkit/strings": "workspace:*",
 		"@288-toolkit/typed-context": "workspace:*",
 		"@288-toolkit/types": "workspace:*",
+		"@288-toolkit/url": "workspace:*",
 		"@288-toolkit/vite-plugin-svelte-inline-component": "workspace:*",
 		"@testing-library/svelte": "^5.1.0"
 	},

--- a/packages/components/video-embed/src/lib/vimeo.ts
+++ b/packages/components/video-embed/src/lib/vimeo.ts
@@ -1,4 +1,5 @@
 import type { Maybe } from '@288-toolkit/types';
+import { urlCanParse } from '@288-toolkit/url';
 
 export type ThumbnailOptions = {
 	width: string;
@@ -23,7 +24,7 @@ export const isVimeoUrl = (url: Maybe<string>): boolean => {
  * - https://vimeo.com/[VIDEO_ID]
  */
 export const getVimeoId = (url: string) => {
-	if (!URL.canParse(url)) {
+	if (!urlCanParse(url)) {
 		return '';
 	}
 	return new URL(url).pathname.replace('/', '')

--- a/packages/components/video-embed/src/lib/youtube.ts
+++ b/packages/components/video-embed/src/lib/youtube.ts
@@ -1,4 +1,5 @@
 import type { Maybe } from '@288-toolkit/types';
+import { urlCanParse } from '@288-toolkit/url';
 
 export type YtThumbnailFormat =
 	| 'default'
@@ -35,7 +36,7 @@ export const getYoutubeId = (url: string) => {
 	if (!url) {
 		return '';
 	}
-	if (!URL.canParse(url)) {
+	if (!urlCanParse(url)) {
 		return '';
 	}
 

--- a/packages/strings/src/index.ts
+++ b/packages/strings/src/index.ts
@@ -1,6 +1,7 @@
 export * from './base64.js';
 export * from './capitalize.js';
 export * from './objectToQueryString.js';
+export * from './normalize.js';
 export * from './removeLineBreaks.js';
 export * from './removeSpaces.js';
 export * from './removeTrailingSlash.js';

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -29,3 +29,9 @@ getEntryUrl(mockEntry).toAbsolute(); // Returns the full URL string.
 getEntryUrl(mockEntry).toString(); // Returns the full URL string.
 getEntryUrl(mockEntry).toSchemeLess(); // Returns the URL string without the scheme, composed of the pathname, search, and hash.
 ```
+
+## `urlCanParse`
+
+Checks if a URL can be parsed.
+
+This is a fallback for environments that don't support the `URL.canParse` method.

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -14,9 +14,15 @@ Check if a URL is external.
 
 Validate if the URL is from the same origin as the request URL.
 
+## `parsedUrl()`
+
+Safely parses a URL and expose and nice API to access the parts of the URL.
+If the URL is not valid, all functions returns null.
+
 ## `createEntryUrlBuilder`
 
 Creates a function that builds URLs for entries.
+Its api is similar to the `parsedUrl` function.
 
 ```ts
 const getEntryUrl = createEntryUrlBuilder({

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -20,14 +20,12 @@ Creates a function that builds URLs for entries.
 
 ```ts
 const getEntryUrl = createEntryUrlBuilder({
-	localize: true,
 	siteUrl: 'https://example.org',
-	homeUri: '__home__'
+	shouldRemoveTrailingSlash: true
 });
 
 getEntryUrl(mockEntry).raw; // The URL object.
 getEntryUrl(mockEntry).toAbsolute(); // Returns the full URL string.
 getEntryUrl(mockEntry).toString(); // Returns the full URL string.
 getEntryUrl(mockEntry).toSchemeLess(); // Returns the URL string without the scheme, composed of the pathname, search, and hash.
-getEntryUrl(mockEntry).toLanguageRelative(); // Returns the entry uri relative to the language.
 ```

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -28,6 +28,7 @@
 		}
 	},
 	"dependencies": {
+		"@288-toolkit/strings": "workspace:^",
 		"@288-toolkit/types": "workspace:^"
 	}
 }

--- a/packages/url/src/createEntryUrlBuilder.ts
+++ b/packages/url/src/createEntryUrlBuilder.ts
@@ -33,7 +33,7 @@ export const createEntryUrlBuilder = ({ siteUrl, shouldRemoveTrailingSlash = tru
 	}
 	const SITE_URL = new URL(siteUrl);
 	return (entry: Entry) => {
-		if (!entry?.url || !URL.canParse(entry.url)) {
+		if (!entry?.url || !urlCanParse(entry.url)) {
 			return {
 				raw: null,
 				encodePath: () => null,

--- a/packages/url/src/createEntryUrlBuilder.ts
+++ b/packages/url/src/createEntryUrlBuilder.ts
@@ -99,7 +99,7 @@ export const createEntryUrlBuilder = ({ siteUrl, shouldRemoveTrailingSlash = tru
 			 * @deprecated Use `toSchemeLess` instead.
 			 */
 			toLanguageRelative() {
-				return url;
+				return url.toString();
 			}
 		};
 	};

--- a/packages/url/src/createEntryUrlBuilder.ts
+++ b/packages/url/src/createEntryUrlBuilder.ts
@@ -1,4 +1,5 @@
 import { removeTrailingSlash } from '@288-toolkit/strings';
+import { normalize } from '@288-toolkit/strings';
 import type { Maybe } from '@288-toolkit/types';
 import { urlCanParse } from './urlCanParse';
 
@@ -37,8 +38,10 @@ export const createEntryUrlBuilder = ({ siteUrl, shouldRemoveTrailingSlash = tru
 			return {
 				raw: null,
 				encodePath: () => null,
+				normalizePath: () => null,
 				toAbsolute: () => null,
 				toSchemeLess: () => null,
+				/** @deprecated Use `toSchemeLess` instead. */
 				toLanguageRelative: () => null,
 				toString: () => null
 			};
@@ -64,6 +67,13 @@ export const createEntryUrlBuilder = ({ siteUrl, shouldRemoveTrailingSlash = tru
 			 */
 			encodePath() {
 				url.pathname = encodeURIComponent(url.pathname);
+			},
+			/**
+			 * Normalizes the pathname by removing accents.
+			 * @see {@link @288-toolkit/strings#normalize}
+			 */
+			normalizePath() {
+				url.pathname = normalize(url.pathname);
 			},
 			/**
 			 * Returns the full URL string.

--- a/packages/url/src/createEntryUrlBuilder.ts
+++ b/packages/url/src/createEntryUrlBuilder.ts
@@ -1,5 +1,6 @@
 import { removeTrailingSlash } from '@288-toolkit/strings';
 import type { Maybe } from '@288-toolkit/types';
+import { urlCanParse } from './urlCanParse';
 
 export type Entry = {
 	url?: Maybe<string>;
@@ -27,7 +28,7 @@ export type EntryUrlParams = {
  * Craft 5 compatible. (Not compatible with Craft 4)
  */
 export const createEntryUrlBuilder = ({ siteUrl, shouldRemoveTrailingSlash = true }: EntryUrlParams) => {
-	if (!URL.canParse(siteUrl)) {
+	if (!urlCanParse(siteUrl)) {
 		throw new Error('Invalid site URL');
 	}
 	const SITE_URL = new URL(siteUrl);

--- a/packages/url/src/createEntryUrlBuilder.ts
+++ b/packages/url/src/createEntryUrlBuilder.ts
@@ -30,10 +30,9 @@ export interface EntryUrl {
 	raw: Maybe<URL>;
 
 	/**
-	 * Makes sure the pathname is properly encoded.
-	 * This can be needed when the pathname contains special characters.
+	 * Returns the pathname decoded.
 	 */
-	encodePath(): EntryUrl;
+	decodedPath(): string;
 
 	/**
 	 * Normalizes the pathname by removing accents.
@@ -81,7 +80,7 @@ export const createEntryUrlBuilder = ({
 		if (!entry?.url || !urlCanParse(entry.url)) {
 			const empty = {
 				raw: null,
-				encodePath: () => empty,
+				decodedPath: () => '',
 				normalizePath: () => empty,
 				toAbsolute: () => null,
 				toSchemeLess: () => null,
@@ -103,12 +102,14 @@ export const createEntryUrlBuilder = ({
 
 		const self = {
 			raw: url,
-			encodePath() {
-				url.pathname = url.pathname.split('/').map(encodeURIComponent).join('/');
-				return self;
+			decodedPath() {
+				return url.pathname.split('/').map(decodeURIComponent).join('/');
 			},
 			normalizePath() {
-				url.pathname = normalize(url.pathname);
+				url.pathname = url.pathname
+					.split('/')
+					.map((part) => normalize(decodeURIComponent(part)))
+					.join('/');
 				return self;
 			},
 			toString() {

--- a/packages/url/src/createEntryUrlBuilder.ts
+++ b/packages/url/src/createEntryUrlBuilder.ts
@@ -1,5 +1,4 @@
-import { removeTrailingSlash } from '@288-toolkit/strings';
-import { normalize } from '@288-toolkit/strings';
+import { normalize, removeTrailingSlash } from '@288-toolkit/strings';
 import type { Maybe } from '@288-toolkit/types';
 import { urlCanParse } from './urlCanParse';
 
@@ -24,27 +23,74 @@ export type EntryUrlParams = {
 	shouldRemoveTrailingSlash?: boolean;
 };
 
+export interface EntryUrl {
+	/**
+	 * The URL object.
+	 */
+	raw: Maybe<URL>;
+
+	/**
+	 * Makes sure the pathname is properly encoded.
+	 * This can be needed when the pathname contains special characters.
+	 */
+	encodePath(): EntryUrl;
+
+	/**
+	 * Normalizes the pathname by removing accents.
+	 * @see {@link @288-toolkit/strings#normalize}
+	 */
+	normalizePath(): EntryUrl;
+
+	/**
+	 * Returns the full URL string.
+	 */
+	toString(): string;
+
+	/**
+	 * Returns the full URL string.
+	 */
+	toAbsolute(): Maybe<string>;
+
+	/**
+	 * Returns the URL string without the scheme, composed of the pathname, search, and hash.
+	 */
+	toSchemeLess(): Maybe<string>;
+
+	/**
+	 * Returns the entry uri relative to the language.
+	 * @deprecated Use `toSchemeLess` instead.
+	 * It now 'assumes' that the language is the first part of the pathname.
+	 */
+	toLanguageRelative(): Maybe<string>;
+	/* @enddeprecated */
+}
+
 /**
  * Creates a function that builds URLs for entries.
  * Craft 5 compatible. (Not compatible with Craft 4)
  */
-export const createEntryUrlBuilder = ({ siteUrl, shouldRemoveTrailingSlash = true }: EntryUrlParams) => {
+export const createEntryUrlBuilder = ({
+	siteUrl,
+	shouldRemoveTrailingSlash = true
+}: EntryUrlParams): ((entry: Entry) => EntryUrl) => {
 	if (!urlCanParse(siteUrl)) {
 		throw new Error('Invalid site URL');
 	}
 	const SITE_URL = new URL(siteUrl);
 	return (entry: Entry) => {
 		if (!entry?.url || !urlCanParse(entry.url)) {
-			return {
+			const empty = {
 				raw: null,
-				encodePath: () => null,
-				normalizePath: () => null,
+				encodePath: () => empty,
+				normalizePath: () => empty,
 				toAbsolute: () => null,
 				toSchemeLess: () => null,
 				/** @deprecated Use `toSchemeLess` instead. */
 				toLanguageRelative: () => null,
-				toString: () => null
-			};
+				/* @enddeprecated */
+				toString: () => ''
+			} satisfies EntryUrl;
+			return empty;
 		}
 		const url = new URL(entry.url);
 		// Replace host and protocol with the site URL
@@ -55,54 +101,32 @@ export const createEntryUrlBuilder = ({ siteUrl, shouldRemoveTrailingSlash = tru
 			url.pathname = removeTrailingSlash(url.pathname);
 		}
 
-		// Return the entry URL object
-		return {
-			/**
-			 * The URL object.
-			 */
+		const self = {
 			raw: url,
-			/**
-			 * Makes sure the pathname is properly encoded.
-			 * This can be needed when the pathname contains special characters.
-			 */
 			encodePath() {
-				url.pathname = encodeURIComponent(url.pathname);
+				url.pathname = url.pathname.split('/').map(encodeURIComponent).join('/');
+				return self;
 			},
-			/**
-			 * Normalizes the pathname by removing accents.
-			 * @see {@link @288-toolkit/strings#normalize}
-			 */
 			normalizePath() {
 				url.pathname = normalize(url.pathname);
+				return self;
 			},
-			/**
-			 * Returns the full URL string.
-			 */
 			toString() {
 				return url.toString();
 			},
-			/**
-			 * Returns the full URL string.
-			 */
 			toAbsolute() {
 				return url.toString();
 			},
-			/**
-			 * Returns the URL string without the scheme, composed of the pathname, search, and hash.
-			 */
 			toSchemeLess() {
 				const { pathname, hash, search } = url;
 				return `${pathname}${search}${hash}`;
 			},
-			/**
-			 * Returns the entry uri relative to the language.
-			 * @deprecated Use `toSchemeLess` instead.
-			 * It now 'assumes' that the language is the first part of the pathname.
-			 */
+			/** @deprecated Use `toSchemeLess` instead. */
 			toLanguageRelative() {
 				return url.pathname.split('/').filter(Boolean).slice(1).join('/');
 			}
 			/* @enddeprecated */
-		};
+		} satisfies EntryUrl;
+		return self;
 	};
 };

--- a/packages/url/src/createEntryUrlBuilder.ts
+++ b/packages/url/src/createEntryUrlBuilder.ts
@@ -97,10 +97,12 @@ export const createEntryUrlBuilder = ({ siteUrl, shouldRemoveTrailingSlash = tru
 			/**
 			 * Returns the entry uri relative to the language.
 			 * @deprecated Use `toSchemeLess` instead.
+			 * It now 'assumes' that the language is the first part of the pathname.
 			 */
 			toLanguageRelative() {
-				return url.toString();
+				return url.pathname.split('/').filter(Boolean).slice(1).join('/');
 			}
+			/* @enddeprecated */
 		};
 	};
 };

--- a/packages/url/src/getLanguageRelativeUri.ts
+++ b/packages/url/src/getLanguageRelativeUri.ts
@@ -1,5 +1,7 @@
 /**
  * Remove the home URI from a URI.
+ * @deprecated Use createEntryUrlBuilder instead.
  */
 export const getLanguageRelativeUri = (uri: string, homeUri: string) =>
 	uri?.replace(homeUri, '') || '';
+/* @enddeprecated */

--- a/packages/url/src/index.ts
+++ b/packages/url/src/index.ts
@@ -1,3 +1,4 @@
 export * from './createEntryUrlBuilder.js';
 export * from './isExternalUrl.js';
 export * from './validateSameOrigin.js';
+export * from './parsedUrl.js';

--- a/packages/url/src/index.ts
+++ b/packages/url/src/index.ts
@@ -2,3 +2,4 @@ export * from './createEntryUrlBuilder.js';
 export * from './isExternalUrl.js';
 export * from './validateSameOrigin.js';
 export * from './parsedUrl.js';
+export * from './urlCanParse.js';

--- a/packages/url/src/parsedUrl.ts
+++ b/packages/url/src/parsedUrl.ts
@@ -1,3 +1,4 @@
+import { normalize } from '@288-toolkit/strings';
 import { urlCanParse } from './urlCanParse';
 
 /**
@@ -24,6 +25,17 @@ export const parsedUrl = (url: string | URL) => {
 				return null;
 			}
 			parsed.pathname = encodeURIComponent(parsed.pathname);
+			return api;
+		},
+		/**
+		 * Normalizes the pathname by removing accents.
+		 * @see {@link @288-toolkit/strings#normalize}
+		 */
+		normalizePath: () => {
+			if (!parsed) {
+				return null;
+			}
+			parsed.pathname = normalize(parsed.pathname);
 			return api;
 		},
 		/**

--- a/packages/url/src/parsedUrl.ts
+++ b/packages/url/src/parsedUrl.ts
@@ -1,9 +1,11 @@
+import { urlCanParse } from './urlCanParse';
+
 /**
  * Safely parses a URL and expose and nice API to access the parts of the URL.
  * If the URL is not valid, all functions returns null.
  */
 export const parsedUrl = (url: string | URL) => {
-	const parsed = URL.canParse(url) ? new URL(url) : null;
+	const parsed = urlCanParse(url) ? new URL(url) : null;
 
 	const api = {
 		/**

--- a/packages/url/src/uriToPath.ts
+++ b/packages/url/src/uriToPath.ts
@@ -2,9 +2,11 @@ import { getLanguageRelativeUri } from './getLanguageRelativeUri.js';
 
 /**
  * Converts a URI to a path.
+ * @deprecated Use createEntryUrlBuilder instead.
  */
 export const uriToPath = (uri: string, homeUri: string) => {
 	const pageUri = getLanguageRelativeUri(uri, homeUri);
 	const path = pageUri ? `/${pageUri}` : '';
 	return path;
 };
+/* @enddeprecated */

--- a/packages/url/src/urlCanParse.ts
+++ b/packages/url/src/urlCanParse.ts
@@ -1,0 +1,15 @@
+/**
+ * Checks if a URL can be parsed.
+ * This is a fallback for environments that don't support the `URL.canParse` method.
+ */
+export const urlCanParse = (url: string) => {
+	if (URL.canParse) {
+		return URL.canParse(url);
+	}
+	try {
+		new URL(url);
+		return true;
+	} catch (error) {
+		return false;
+	}
+};

--- a/packages/url/test/getEntryUrl.spec.ts
+++ b/packages/url/test/getEntryUrl.spec.ts
@@ -80,6 +80,26 @@ describe('`toSchemeLess` should return the pathname, search params and hash', ()
 	});
 });
 
+describe('`normalizePath` should return the normalized pathname', () => {
+	test('removes accents', () => {
+		const localMock = { ...mockEntry };
+		const getEntryUrl = createEntryUrlBuilder(globals);
+		localMock.url = 'https://example.org/en/àrticlés/my-artïçle/';
+		const normalizedPath = getEntryUrl(localMock).normalizePath().toSchemeLess();
+		expect(normalizedPath).toBe('/articles/my-article');
+	});
+});
+
+describe('`encodePath` should return the encoded pathname', () => {
+	test('removes accents', () => {
+		const localMock = { ...mockEntry };
+		const getEntryUrl = createEntryUrlBuilder(globals);
+		localMock.url = 'https://example.org/en/àrticlés/my-artïçle/';
+		const encodedPath = getEntryUrl(localMock).encodePath().toSchemeLess();
+		expect(encodedPath).toBe('/en/%25C3%25A0rticl%25C3%25A9s/my-art%25C3%25AF%25C3%25A7le');
+	});
+});
+
 /**
  * @deprecated
  */

--- a/packages/url/test/getEntryUrl.spec.ts
+++ b/packages/url/test/getEntryUrl.spec.ts
@@ -79,3 +79,17 @@ describe('`toSchemeLess` should return the pathname, search params and hash', ()
 		expect(getEntryUrl(localMock).toSchemeLess()).toBe('/en/articles/my-article?test=yes#hash');
 	});
 });
+
+/**
+ * @deprecated
+ */
+describe('`toLanguageRelative` should return the pathname relative to the language', () => {
+	test('removes the language from the pathname', () => {
+		const localMock = { ...mockEntry };
+		const getEntryUrl = createEntryUrlBuilder(globals);
+		localMock.url = 'https://example.org/en/articles/my-article/';
+		const languageRelativePath = getEntryUrl(localMock).toLanguageRelative();
+		expect(languageRelativePath).toBe('articles/my-article');
+	});
+});
+/* @enddeprecated */

--- a/packages/url/test/getEntryUrl.spec.ts
+++ b/packages/url/test/getEntryUrl.spec.ts
@@ -86,17 +86,17 @@ describe('`normalizePath` should return the normalized pathname', () => {
 		const getEntryUrl = createEntryUrlBuilder(globals);
 		localMock.url = 'https://example.org/en/àrticlés/my-artïçle/';
 		const normalizedPath = getEntryUrl(localMock).normalizePath().toSchemeLess();
-		expect(normalizedPath).toBe('/articles/my-article');
+		expect(normalizedPath).toBe('/en/articles/my-article');
 	});
 });
 
-describe('`encodePath` should return the encoded pathname', () => {
-	test('removes accents', () => {
+describe('`decodedPath` should return the decoded pathname', () => {
+	test('decodes the pathname', () => {
 		const localMock = { ...mockEntry };
 		const getEntryUrl = createEntryUrlBuilder(globals);
 		localMock.url = 'https://example.org/en/àrticlés/my-artïçle/';
-		const encodedPath = getEntryUrl(localMock).encodePath().toSchemeLess();
-		expect(encodedPath).toBe('/en/%25C3%25A0rticl%25C3%25A9s/my-art%25C3%25AF%25C3%25A7le');
+		const decodedPath = getEntryUrl(localMock).decodedPath();
+		expect(decodedPath).toBe('/en/àrticlés/my-artïçle');
 	});
 });
 

--- a/packages/url/test/getEntryUrl.spec.ts
+++ b/packages/url/test/getEntryUrl.spec.ts
@@ -1,99 +1,81 @@
 import { describe, expect, test } from 'vitest';
 import { createEntryUrlBuilder, type EntryUrlParams } from '../src/createEntryUrlBuilder';
 
-const HOME_URI = '__home__';
 const SITE_URL = 'https://example.org';
 
 const mockEntry = {
-	language: 'en',
-	uri: 'articles/my-article'
+	url: 'https://example.org/articles/my-article'
 };
 
-const globalsLocalized = {
-	localize: true,
-	siteUrl: SITE_URL,
-	homeUri: HOME_URI
+const globals = {
+	siteUrl: SITE_URL
 } satisfies EntryUrlParams;
-
-const globalsNonLocalized = {
-	localize: false,
-	siteUrl: SITE_URL,
-	homeUri: HOME_URI
-} satisfies EntryUrlParams;
-
-const mockUrlLocalized = `${globalsLocalized.siteUrl}/${mockEntry.language}/${mockEntry.uri}`;
-const mockUrlNonLocalized = `${globalsNonLocalized.siteUrl}/${mockEntry.uri}`;
 
 describe('`raw` property should return the url object', () => {
-	test('localized', () => {
-		const getEntryUrl = createEntryUrlBuilder(globalsLocalized);
+	test('matches the mock entry url', () => {
+		const getEntryUrl = createEntryUrlBuilder(globals);
 		const rawUrl = getEntryUrl(mockEntry).raw;
-		expect(rawUrl).toMatchObject(new URL(mockUrlLocalized));
+		expect(rawUrl).toMatchObject(new URL(mockEntry.url));
 	});
-
-	test('non-localized', () => {
-		const getEntryUrl = createEntryUrlBuilder(globalsNonLocalized);
-		const rawUrl = getEntryUrl(mockEntry).raw;
-		expect(rawUrl).toMatchObject(new URL(mockUrlNonLocalized));
+	test('returns null if the url is not valid', () => {
+		const getEntryUrl = createEntryUrlBuilder(globals);
+		const rawUrl = getEntryUrl({ url: 'invalid-url' }).raw;
+		expect(rawUrl).toBeNull();
 	});
 });
 
 describe('`toAbsolute` should return the full url string', () => {
-	test('localized', () => {
-		const getEntryUrl = createEntryUrlBuilder(globalsLocalized);
+	test('matches the mock entry url', () => {
+		const getEntryUrl = createEntryUrlBuilder(globals);
 		const fullUrl = getEntryUrl(mockEntry).toAbsolute();
-		expect(fullUrl).toBe(mockUrlLocalized);
+		expect(fullUrl).toBe(mockEntry.url);
 	});
-	test('non-localized', () => {
-		const getEntryUrl = createEntryUrlBuilder(globalsNonLocalized);
-		const fullUrl = getEntryUrl(mockEntry).toAbsolute();
-		expect(fullUrl).toBe(mockUrlNonLocalized);
+	test('returns null if the url is not valid', () => {
+		const getEntryUrl = createEntryUrlBuilder(globals);
+		const fullUrl = getEntryUrl({ url: 'invalid-url' }).toAbsolute();
+		expect(fullUrl).toBeNull();
+	});
+	test('removes trailing slash if shouldRemoveTrailingSlash is true', () => {
+		const localMock = { ...mockEntry };
+		const getEntryUrl = createEntryUrlBuilder({ ...globals, shouldRemoveTrailingSlash: true });
+		localMock.url = 'https://example.org/articles/my-article/';
+		const fullUrl = getEntryUrl(localMock).toAbsolute();
+		expect(fullUrl).toBe(mockEntry.url);
+	});
+	test('does not remove trailing slash if shouldRemoveTrailingSlash is false', () => {
+		const localMock = { ...mockEntry };
+		const getEntryUrl = createEntryUrlBuilder({ ...globals, shouldRemoveTrailingSlash: false });
+		localMock.url = 'https://example.org/en/articles/my-article/';
+		const fullUrl = getEntryUrl(localMock).toAbsolute();
+		expect(fullUrl).toBe(localMock.url);
 	});
 });
 
 describe('`toString` should return the full url string', () => {
-	test('localized', () => {
-		const getEntryUrl = createEntryUrlBuilder(globalsLocalized);
+	test('same as `toAbsolute`', () => {
+		const getEntryUrl = createEntryUrlBuilder(globals);
 		const fullUrl = getEntryUrl(mockEntry).toString();
-		expect(fullUrl).toBe(mockUrlLocalized);
-	});
-	test('non-localized', () => {
-		const getEntryUrl = createEntryUrlBuilder(globalsNonLocalized);
-		const fullUrl = getEntryUrl(mockEntry).toString();
-		expect(fullUrl).toBe(mockUrlNonLocalized);
-	});
-});
-
-describe('`toLanguageRelative` should return the entry uri', () => {
-	test('localized', () => {
-		const getEntryUrl = createEntryUrlBuilder(globalsLocalized);
-		const languageRelativeUrl = getEntryUrl(mockEntry).toLanguageRelative();
-		expect(languageRelativeUrl).toBe(`/${mockEntry.uri}`);
-	});
-	test('non-localized', () => {
-		const getEntryUrl = createEntryUrlBuilder(globalsNonLocalized);
-		const languageRelativeUrl = getEntryUrl(mockEntry).toLanguageRelative();
-		expect(languageRelativeUrl).toBe(`/${mockEntry.uri}`);
+		expect(fullUrl).toBe(getEntryUrl(mockEntry).toAbsolute());
 	});
 });
 
 describe('`toSchemeLess` should return the pathname, search params and hash', () => {
-	test('localized', () => {
+	test('pathname only', () => {
 		const localMock = { ...mockEntry };
-		const getEntryUrl = createEntryUrlBuilder(globalsLocalized);
+		const getEntryUrl = createEntryUrlBuilder(globals);
+		localMock.url = 'https://example.org/en/articles/my-article/';
 		expect(getEntryUrl(localMock).toSchemeLess()).toBe('/en/articles/my-article');
-		localMock.uri = 'articles/my-article?test=yes';
-		expect(getEntryUrl(localMock).toSchemeLess()).toBe('/en/articles/my-article?test=yes');
-		localMock.uri = 'articles/my-article?test=yes#hash';
-		expect(getEntryUrl(localMock).toSchemeLess()).toBe('/en/articles/my-article?test=yes#hash');
 	});
-	test('non-localized', () => {
+	test('pathname and search params', () => {
 		const localMock = { ...mockEntry };
-		const getEntryUrl = createEntryUrlBuilder(globalsNonLocalized);
-		expect(getEntryUrl(localMock).toSchemeLess()).toBe('/articles/my-article');
-		localMock.uri = 'articles/my-article?test=yes';
-		expect(getEntryUrl(localMock).toSchemeLess()).toBe('/articles/my-article?test=yes');
-		localMock.uri = 'articles/my-article?test=yes#hash';
-		expect(getEntryUrl(localMock).toSchemeLess()).toBe('/articles/my-article?test=yes#hash');
+		const getEntryUrl = createEntryUrlBuilder(globals);
+		localMock.url = 'https://example.org/en/articles/my-article?test=yes';
+		expect(getEntryUrl(localMock).toSchemeLess()).toBe('/en/articles/my-article?test=yes');
+	});
+	test('pathname, search params and hash', () => {
+		const localMock = { ...mockEntry };
+		const getEntryUrl = createEntryUrlBuilder(globals);
+		localMock.url = 'https://example.org/en/articles/my-article?test=yes#hash';
+		expect(getEntryUrl(localMock).toSchemeLess()).toBe('/en/articles/my-article?test=yes#hash');
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       '@288-toolkit/types':
         specifier: workspace:*
         version: link:../../types
+      '@288-toolkit/url':
+        specifier: workspace:*
+        version: link:../../url
       '@288-toolkit/vite-plugin-svelte-inline-component':
         specifier: workspace:*
         version: link:../../vite-plugin-svelte-inline-component
@@ -544,6 +547,9 @@ importers:
 
   packages/url:
     dependencies:
+      '@288-toolkit/strings':
+        specifier: workspace:^
+        version: link:../strings
       '@288-toolkit/types':
         specifier: workspace:^
         version: link:../types
@@ -873,6 +879,7 @@ packages:
 
   /@emotion/memoize@0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    requiresBuild: true
     dev: false
     optional: true
 

--- a/sandbox/vite.config.ts
+++ b/sandbox/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
 	plugins: [sveltekit()],
 	server: {
-		port: 3000,
+		port: process.env.CI || process.env.VITEST ? undefined : 3000,
 		strictPort: true
 	}
 });

--- a/sandbox/vite.config.ts
+++ b/sandbox/vite.config.ts
@@ -1,10 +1,12 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
+const isCI = process.env.CI || process.env.VITEST;
+
 export default defineConfig({
 	plugins: [sveltekit()],
 	server: {
-		port: process.env.CI || process.env.VITEST ? undefined : 3000,
-		strictPort: true
+		port: isCI ? undefined : 3000,
+		strictPort: !isCI
 	}
 });


### PR DESCRIPTION
This PR bring some changes around the fact that Craft 5 now returns complete, full url for entries. Since they are based on the cms, they may not be want we want to use: We do not want the CMS to have the final words on that.

Old api were deprecated.