### PR TITLE
(feat) Add fetchTimeout()

### DIFF
--- a/.changeset/grumpy-comics-wonder.md
+++ b/.changeset/grumpy-comics-wonder.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/http': minor
+---
+
+(feat) Add fetchTimeout()

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -38,6 +38,15 @@ return new Response('', {
 });
 ```
 
+## `fetchTimeout`
+
+Fetch with a timeout. Defaults to 20 seconds.
+
+```ts
+// 5 second timeout
+const response = await fetchTimeout(url, { ... }, 5000);
+```
+
 ## `isRedirectResponse`
 
 Returns `true` if the response is a redirect response.

--- a/packages/http/src/fetchTimeout.ts
+++ b/packages/http/src/fetchTimeout.ts
@@ -1,0 +1,21 @@
+/**
+ * Fetch with a timeout
+ * @param url - The URL to fetch
+ * @param options - The options for the fetch
+ * @param timeout - The timeout in milliseconds. Defaults to 20 seconds.
+ * @returns The response from the fetch
+ */
+export const fetchTimeout = async (
+	url: RequestInfo | URL,
+	options: RequestInit = {},
+	timeout = 20000
+) => {
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+	try {
+		return fetch(url, { ...options, signal: controller.signal });
+	} finally {
+		clearTimeout(timeoutId);
+	}
+};

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,4 +1,5 @@
 export * from './cacheHeaders.js';
+export * from './fetchTimeout.js';
 export * from './getLangFromRequest.js';
 export * from './isRedirectResponse.js';
 export * from './parseAcceptLanguage.js';

--- a/packages/http/src/parseAcceptLanguage.ts
+++ b/packages/http/src/parseAcceptLanguage.ts
@@ -52,8 +52,8 @@ export const parseAcceptLanguage = (al: string): Maybe<AcceptLanguageEntry[]> =>
 				return result;
 			});
 		})
-		.filter(Boolean)
+		.filter((x) => !!x)
 		.sort(
 			(a: AcceptLanguageEntry, b: AcceptLanguageEntry) => b.priority - a.priority
-		) as AcceptLanguageEntry[];
+		);
 };

--- a/packages/http/src/parseAcceptLanguage.ts
+++ b/packages/http/src/parseAcceptLanguage.ts
@@ -53,7 +53,5 @@ export const parseAcceptLanguage = (al: string): Maybe<AcceptLanguageEntry[]> =>
 			});
 		})
 		.filter((x) => !!x)
-		.sort(
-			(a: AcceptLanguageEntry, b: AcceptLanguageEntry) => b.priority - a.priority
-		);
+		.sort((a: AcceptLanguageEntry, b: AcceptLanguageEntry) => b.priority - a.priority);
 };


### PR DESCRIPTION
The default fetch api does not allow for a custom timeout value. The default would then be left for the server to decide, which is often 60 seconds. That way too long.

This change add a new wrapper with a 20 seconds default.

Since we have 60 seconds ourselve to generate a response (vercel's limit) and we often have more than one fetch to issue, 20 seconds seems like a good default.