### PR TITLE
(feat) site uri vs i18n

### DIFF
--- a/.changeset/heavy-suits-own.md
+++ b/.changeset/heavy-suits-own.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/hooks': minor
+---
+
+Add new siteRouter hook

--- a/.changeset/real-cheetahs-grow.md
+++ b/.changeset/real-cheetahs-grow.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/http': minor
+---
+
+Add acceptedLanguage, deprecate getLangFromRequest

--- a/.changeset/seven-singers-clean.md
+++ b/.changeset/seven-singers-clean.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/i18n': major
+---
+
+Use siteRouter values to find our values

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -108,3 +108,24 @@ export const handle = sequence(
 This will add the following header:
 
 -   `content-security-policy`, "frame-ancestors 'self' https://my-url.com https://another-url.com"
+
+### `createSiteRouter()`
+
+Creates a site router handle.
+
+```ts
+import { createSiteRouter } from '@288-toolkit/hooks/server';
+
+export const handle = sequence(createSiteRouter({
+	defaultSiteUri: 'en',
+	defaultEntryUri: '__home-page__'
+}));
+```
+
+The following options are available:
+
+- `defaultSiteUri`: The default site uri, when the pathname is empty.
+- `defaultEntryUri`: The default entry uri, when the pathname is empty.
+- `siteHandle`: A function to format the site handle.
+- `pathnameSplitter`: A function to split the pathname into site and entry parts.
+- `partsToSiteRouterObject`: A function to convert the parts into a site router object.

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -116,16 +116,18 @@ Creates a site router handle.
 ```ts
 import { createSiteRouter } from '@288-toolkit/hooks/server';
 
-export const handle = sequence(createSiteRouter({
-	defaultSiteUri: 'en',
-	defaultEntryUri: '__home-page__'
-}));
+export const handle = sequence(
+	createSiteRouter({
+		defaultSiteUri: 'en',
+		defaultEntryUri: '__home-page__'
+	})
+);
 ```
 
 The following options are available:
 
-- `defaultSiteUri`: The default site uri, when the pathname is empty.
-- `defaultEntryUri`: The default entry uri, when the pathname is empty.
-- `siteHandle`: A function to format the site handle.
-- `pathnameSplitter`: A function to split the pathname into site and entry parts.
-- `partsToSiteRouterObject`: A function to convert the parts into a site router object.
+-   `defaultSiteUri`: The default site uri, when the pathname is empty.
+-   `defaultEntryUri`: The default entry uri, when the pathname is empty.
+-   `siteHandle`: A function to format the site handle.
+-   `pathnameSplitter`: A function to split the pathname into site and entry parts.
+-   `partsToSiteRouterObject`: A function to convert the parts into a site router object.

--- a/packages/hooks/src/server/index.ts
+++ b/packages/hooks/src/server/index.ts
@@ -3,3 +3,4 @@ export * from './http-auth.js';
 export * from './performance.js';
 export * from './preloads.js';
 export * from './security.js';
+export * from './site-router.js';

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -1,4 +1,5 @@
-import type { Handle, RequestEvent } from '@sveltejs/kit';
+import type { Handle, RequestEvent, Resolve } from '@sveltejs/kit';
+import { REPLCommand } from 'repl';
 
 /**
  * The uri object with site and entry properties.
@@ -88,9 +89,14 @@ export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = ({
 	pathnameSplitter = defaultPathnameSplitter,
 	partsToSiteRouterObject = defaultPartsToSiteRouterObject
 }: SiteRouterHandleOptions) => {
-	return <L extends SiteRouterLocals>({ event, resolve }) => {
-		const url = new URL(event.url);
-		const path = url.pathname;
+	return <L extends SiteRouterLocals>({
+		event,
+		resolve
+	}: {
+		event: RequestEvent;
+		resolve: Resolve;
+	}) => {
+		const path = event.url.pathname;
 		const parts = pathnameSplitter(path);
 		const locals = event.locals as L;
 

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -82,7 +82,9 @@ export const defaultSiteHandle = <L extends SiteRouterLocals>(event: RequestEven
  * @param options The options for the siteRouter handle.
  * @returns The siteRouter handle.
  */
-export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = <L extends SiteRouterLocals>({
+export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = <
+	L extends SiteRouterLocals
+>({
 	defaultSiteUri,
 	defaultEntryUri = '',
 	siteHandle = defaultSiteHandle,

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -82,14 +82,14 @@ export const defaultSiteHandle = <L extends SiteRouterLocals>(event: RequestEven
  * @param options The options for the siteRouter handle.
  * @returns The siteRouter handle.
  */
-export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = ({
+export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = <L extends SiteRouterLocals>({
 	defaultSiteUri,
 	defaultEntryUri = '',
 	siteHandle = defaultSiteHandle,
 	pathnameSplitter = defaultPathnameSplitter,
 	partsToSiteRouterObject = defaultPartsToSiteRouterObject
 }: SiteRouterHandleOptions) => {
-	return <L extends SiteRouterLocals>({
+	return <LL extends SiteRouterLocals = L>({
 		event,
 		resolve
 	}: {
@@ -98,7 +98,7 @@ export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = ({
 	}) => {
 		const path = event.url.pathname;
 		const parts = pathnameSplitter(path);
-		const locals = event.locals as L;
+		const locals = event.locals as LL;
 
 		if (!parts.length) {
 			locals.siteRouter = {

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -1,0 +1,117 @@
+import type { Handle, RequestEvent } from '@sveltejs/kit';
+
+/**
+ * The uri object with site and entry properties.
+ */
+export type SiteRouter = {
+	default?: true;
+	site: {
+		uri: string;
+		handle: string;
+	};
+	entry: {
+		uri: string;
+	};
+};
+
+/**
+ * Options for the siteRouter handle.
+ */
+export type SiteRouterHandleOptions = {
+	defaultSiteUri: string;
+	defaultEntryUri?: string;
+	siteHandle?: (event: RequestEvent) => string;
+	pathnameSplitter?: (pathname: string) => string[];
+	partsToSiteRouterObject?: (parts: string[]) => SiteRouter;
+};
+
+/**
+ * Let's make sure the locals object has the uri object with site and entry properties.
+ */
+type SiteRouterLocals = App.Locals & {
+	siteRouter: SiteRouter;
+};
+
+/**
+ * Split the pathname into site and entry parts.
+ * This default implementation splits the pathname by the '/' character and filters out empty strings.
+ * @param pathname The pathname to split.
+ * @returns The site and entry parts.
+ */
+export const defaultPathnameSplitter = (pathname: string) => pathname.split('/').filter((x) => !!x);
+
+/**
+ * Convert the parts into a uri object.
+ * This default implementation takes the first part as the site and the rest as the entry.
+ * @param parts The parts to convert.
+ * @returns The uri object.
+ */
+export const defaultPartsToSiteRouterObject = (parts: string[]) =>
+	({
+		site: {
+			uri: parts[0],
+			handle: ''
+		},
+		entry: {
+			uri: parts.slice(1).join('/')
+		}
+	}) satisfies SiteRouter;
+
+/**
+ * Default site handle formatter.
+ * This default implementation replaces all '-' characters with '_' characters.
+ * @param event The request event.
+ * @returns The formatted site handle.
+ */
+export const defaultSiteHandle = <L extends SiteRouterLocals>(event: RequestEvent) => {
+	const locals = event.locals as L;
+	return locals.siteRouter.site.uri.replaceAll('-', '_');
+};
+
+/**
+ * This handle is responsible for setting the siteRouter object in the locals object.
+ * Its responsibility is to split the pathname into site and entry parts and convert
+ * them into a siteRouter object. It also formats the site handle.
+ *
+ * Many parts of the implementation are customizable through the options.
+ *
+ * Those values will be used by other hooks and should also be used when requesting
+ * an entry from the CMS.
+ *
+ * @param options The options for the siteRouter handle.
+ * @returns The siteRouter handle.
+ */
+export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = ({
+	defaultSiteUri,
+	defaultEntryUri = '',
+	siteHandle = defaultSiteHandle,
+	pathnameSplitter = defaultPathnameSplitter,
+	partsToSiteRouterObject = defaultPartsToSiteRouterObject
+}: SiteRouterHandleOptions) => {
+	return <L extends SiteRouterLocals>({ event, resolve }) => {
+		const url = new URL(event.url);
+		const path = url.pathname;
+		const parts = pathnameSplitter(path);
+		const locals = event.locals as L;
+
+		if (!parts.length) {
+			locals.siteRouter = {
+				default: true,
+				site: {
+					uri: defaultSiteUri,
+					handle: ''
+				},
+				entry: {
+					uri: defaultEntryUri
+				}
+			};
+		} else {
+			locals.siteRouter = partsToSiteRouterObject(parts);
+		}
+
+		// Properly format the site handle
+		locals.siteRouter.site.handle = siteHandle(event);
+
+		return resolve(event);
+	};
+};

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -1,5 +1,4 @@
-import type { Handle, RequestEvent, Resolve } from '@sveltejs/kit';
-import { REPLCommand } from 'repl';
+import type { Handle, RequestEvent } from '@sveltejs/kit';
 
 /**
  * The uri object with site and entry properties.
@@ -94,10 +93,7 @@ export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = <
 	return <LL extends SiteRouterLocals = L>({
 		event,
 		resolve
-	}: {
-		event: RequestEvent;
-		resolve: Resolve;
-	}) => {
+	}: Parameters<Handle>[0]) => {
 		const path = event.url.pathname;
 		const parts = pathnameSplitter(path);
 		const locals = event.locals as LL;

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -115,8 +115,10 @@ export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = ({
 			locals.siteRouter = partsToSiteRouterObject(parts);
 		}
 
-		// Properly format the site handle
-		locals.siteRouter.site.handle = siteHandle(event);
+		// Make sure the site handle is set and properly formatted
+		if (!locals.siteRouter.site.handle) {
+			locals.siteRouter.site.handle = siteHandle(event);
+		}
 
 		return resolve(event);
 	};

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -90,10 +90,7 @@ export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = <
 	pathnameSplitter = defaultPathnameSplitter,
 	partsToSiteRouterObject = defaultPartsToSiteRouterObject
 }: SiteRouterHandleOptions) => {
-	return <LL extends SiteRouterLocals = L>({
-		event,
-		resolve
-	}: Parameters<Handle>[0]) => {
+	return <LL extends SiteRouterLocals = L>({ event, resolve }: Parameters<Handle>[0]) => {
 		const path = event.url.pathname;
 		const parts = pathnameSplitter(path);
 		const locals = event.locals as LL;

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -55,7 +55,7 @@ Returns `true` if the response is a redirect response.
 const isRedirectResponse: (response: Response) => boolean;
 ```
 
-## `getLangFromRequest`
+## `getLangFromRequest` (deprecated)
 
 Get the language from the request.
 
@@ -78,6 +78,17 @@ type AcceptLanguageEntry = {
 };
 
 const parseAcceptLanguage = (acceptLanguage: string): Maybe<AcceptLanguageEntry[]>
+```
+
+## `acceptedLanguage`
+
+Get the accepted language from the request.
+
+```ts
+const language = acceptedLanguage(request, {
+	supportedLanguages: ['en', 'fr'],
+	defaultLanguage: 'en'
+});
 ```
 
 ## `getVercelIpHeaders`

--- a/packages/http/src/accepted-language.ts
+++ b/packages/http/src/accepted-language.ts
@@ -1,4 +1,4 @@
-import { parseAcceptLanguage } from './parseAcceptLanguage.ts';
+import { parseAcceptLanguage } from './parseAcceptLanguage.js';
 
 export type AcceptedLanguageParams<Language extends string> = {
 	supportedLanguages: Readonly<Language[]>;

--- a/packages/http/src/accepted-language.ts
+++ b/packages/http/src/accepted-language.ts
@@ -1,0 +1,32 @@
+import { parseAcceptLanguage } from "./parseAcceptLanguage.ts";
+
+export type AcceptedLanguageParams<Language extends string> = {
+	supportedLanguages: Readonly<Language[]>;
+	defaultLanguage: Language;
+};
+
+/**
+ * Get the supported language from the request's headers.
+ * @see parseAcceptLanguage()
+ *
+ * @param request The request object.
+ * @param params The parameters.
+ */
+export const acceptedLanguage = <Language extends string>(request: Request, {
+	supportedLanguages,
+	defaultLanguage
+}: AcceptedLanguageParams<Language>) => {
+	// Extract and parse the accept-language header
+	const acceptLanguage = request.headers.get('accept-language');
+	if (acceptLanguage) {
+		const languages = parseAcceptLanguage(acceptLanguage)
+			?.filter(({ lang }) => supportedLanguages.includes(lang as Language))
+			.map(({ lang }) => lang);
+		// If there is matches, return the first one
+		if (languages?.length) {
+			return languages[0] as Language;
+		}
+	}
+
+	return defaultLanguage;
+};

--- a/packages/http/src/accepted-language.ts
+++ b/packages/http/src/accepted-language.ts
@@ -1,4 +1,4 @@
-import { parseAcceptLanguage } from "./parseAcceptLanguage.ts";
+import { parseAcceptLanguage } from './parseAcceptLanguage.ts';
 
 export type AcceptedLanguageParams<Language extends string> = {
 	supportedLanguages: Readonly<Language[]>;
@@ -12,10 +12,10 @@ export type AcceptedLanguageParams<Language extends string> = {
  * @param request The request object.
  * @param params The parameters.
  */
-export const acceptedLanguage = <Language extends string>(request: Request, {
-	supportedLanguages,
-	defaultLanguage
-}: AcceptedLanguageParams<Language>) => {
+export const acceptedLanguage = <Language extends string>(
+	request: Request,
+	{ supportedLanguages, defaultLanguage }: AcceptedLanguageParams<Language>
+) => {
 	// Extract and parse the accept-language header
 	const acceptLanguage = request.headers.get('accept-language');
 	if (acceptLanguage) {

--- a/packages/http/src/getLangFromRequest.ts
+++ b/packages/http/src/getLangFromRequest.ts
@@ -1,4 +1,4 @@
-import { acceptedLanguage } from "./accepted-language.js";
+import { acceptedLanguage } from './accepted-language.js';
 
 /**
  * Get the language from the request

--- a/packages/http/src/getLangFromRequest.ts
+++ b/packages/http/src/getLangFromRequest.ts
@@ -1,7 +1,12 @@
-import { parseAcceptLanguage } from './parseAcceptLanguage.js';
+import { acceptedLanguage } from "./accepted-language.js";
 
 /**
  * Get the language from the request
+ *
+ * @deprecated Use the values from your locals object instead.
+ * Use the `@88-toolkit/hooks/server/site-uri#createSiteUri()` handle to set
+ * the `uri` property in the locals object.
+ * You can also check the `acceptedLanguage` function to get the language from the request's headers.
  */
 export const getLangFromRequest = <Language extends string>(
 	request: Request,
@@ -17,18 +22,10 @@ export const getLangFromRequest = <Language extends string>(
 		return pathLang;
 	}
 
-	// Check user-agent accepted languages next
-	const acceptLanguage = request.headers.get('accept-language');
-	if (acceptLanguage) {
-		const languages = parseAcceptLanguage(acceptLanguage)
-			?.filter(({ lang }) => supportedLanguages.includes(lang as Language))
-			.map(({ lang }) => lang);
-		// If there is a match, return it
-		if (languages?.length) {
-			return languages[0] as Language;
-		}
-	}
-
-	// Fallback to default language
-	return defaultLanguage;
+	// Check user-agent accepted languages next, with fallback to default language
+	return acceptedLanguage(request, {
+		supportedLanguages,
+		defaultLanguage
+	});
 };
+/* @enddeprecated */

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,3 +1,4 @@
+export * from './accepted-language.js';
 export * from './cacheHeaders.js';
 export * from './fetchTimeout.js';
 export * from './getLangFromRequest.js';

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -17,7 +17,7 @@ You can create three i18n handles with the `createI18nHandles` function:
 ```ts
 import { createI18nHandles } from '@288-toolkit/i18n/server';
 
-const { langInfo, langRedirect, langAttribute } = createI18nHandles({
+const { langInfo, langRedirect, langAttribute } = createI18nHandles<App.Locals>({
 	supportedLocales: ['en-ca', 'fr-ca'],
 	defaultLocale: 'en-ca'
 });

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -14,15 +14,25 @@ You can create three i18n handles with the `createI18nHandles` function:
     than one supported locale) and the request is for the root
 -   `langAttribute`: Renders the correct html lang attribute
 
+In order to use these handles, you must use the `siteRouter` handle, provided by the
+`@288-toolkit/hooks` package. If you do not use it, make sure to provide a custom replacement hooks
+that will set the `siteRouter` object in the locals object.
+
 ```ts
+import { createSiteRouter } from '@288-toolkit/hooks/server';
 import { createI18nHandles } from '@288-toolkit/i18n/server';
+
+const siteRouter = createSiteRouter({
+	defaultSiteUri: 'en',
+	defaultEntryUri: '__home-page__'
+});
 
 const { langInfo, langRedirect, langAttribute } = createI18nHandles<App.Locals>({
 	supportedLocales: ['en-ca', 'fr-ca'],
 	defaultLocale: 'en-ca'
 });
 
-export const handle = sequence(langInfo, langRedirect, langAttribute);
+export const handle = sequence(siteRouter, langInfo, langRedirect, langAttribute);
 ```
 
 If you want your site's localization to be based on a language, use `langInfo` and `langRedirect`.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -36,6 +36,7 @@
 		"svelte": "4.x || 5.x"
 	},
 	"dependencies": {
+		"@288-toolkit/hooks": "workspace:*",
 		"@288-toolkit/http": "workspace:*",
 		"@288-toolkit/types": "workspace:*",
 		"esm-env": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: link:packages/vite-plugin-svelte-inline-component
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.10)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7))
       svelte:
         specifier: 4.x || 5.x
         version: 4.0.0
@@ -35,7 +35,7 @@ importers:
         version: 2.3.1(svelte@4.0.0)(typescript@5.4.5)
       '@sveltejs/vite-plugin-svelte':
         specifier: 3.1.0
-        version: 3.1.0(svelte@4.0.0)(vite@5.2.10)
+        version: 3.1.0(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7))
       '@types/node':
         specifier: 20.12.7
         version: 20.12.7
@@ -68,16 +68,16 @@ importers:
         version: 3.2.3(prettier@3.2.5)(svelte@4.0.0)
       prettier-plugin-tailwindcss:
         specifier: 0.5.14
-        version: 0.5.14(prettier-plugin-organize-imports@3.2.4)(prettier-plugin-svelte@3.2.3)(prettier@3.2.5)
+        version: 0.5.14(prettier-plugin-organize-imports@3.2.4(prettier@3.2.5)(typescript@5.4.5))(prettier-plugin-svelte@3.2.3(prettier@3.2.5)(svelte@4.0.0))(prettier@3.2.5)
       svelte-check:
         specifier: 3.6.9
-        version: 3.6.9(postcss@8.4.49)(svelte@4.0.0)
+        version: 3.6.9(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)
       svelte-fsm:
         specifier: 1.2.0
         version: 1.2.0
       svelte-preprocess:
         specifier: 5.1.4
-        version: 5.1.4(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
+        version: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
       tslib:
         specifier: 2.6.2
         version: 2.6.2
@@ -107,10 +107,10 @@ importers:
         version: link:../types
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       motion:
         specifier: 10.x
-        version: 10.0.0(react-dom@18.3.1)(react@18.3.1)
+        version: 10.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       svelte:
         specifier: 4.x || 5.x
         version: 4.0.0
@@ -179,7 +179,7 @@ importers:
         version: link:../../math
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       svelte:
         specifier: 4.x || 5.x
         version: 4.0.0
@@ -194,7 +194,7 @@ importers:
         version: link:../../vite-plugin-svelte-inline-component
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       esm-env:
         specifier: 1.0.0
         version: 1.0.0
@@ -207,10 +207,10 @@ importers:
         version: 10.0.0
       '@testing-library/svelte':
         specifier: ^5.1.0
-        version: 5.1.0(svelte@4.0.0)(vite@5.2.11)(vitest@2.1.6)
+        version: 5.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))(vitest@2.1.6(@types/node@20.12.7)(jsdom@24.0.0))
       svelte-preprocess:
         specifier: 5.1.4
-        version: 5.1.4(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
+        version: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
 
   packages/components/html-elements:
     dependencies:
@@ -270,7 +270,7 @@ importers:
         version: link:../../ui
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       esm-env:
         specifier: 1.0.0
         version: 1.0.0
@@ -303,7 +303,7 @@ importers:
         version: 1.0.0
       motion:
         specifier: 10.x
-        version: 10.0.0(react-dom@18.3.1)(react@18.3.1)
+        version: 10.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       svelte:
         specifier: 4.x || 5.x
         version: 4.0.0
@@ -313,10 +313,10 @@ importers:
         version: link:../../vite-plugin-svelte-inline-component
       '@testing-library/svelte':
         specifier: ^5.1.0
-        version: 5.1.0(svelte@4.0.0)(vite@5.2.10)(vitest@2.1.6)
+        version: 5.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))(vitest@2.1.6(@types/node@20.12.7)(jsdom@24.0.0))
       svelte-preprocess:
         specifier: 5.1.4
-        version: 5.1.4(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
+        version: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
 
   packages/components/video-embed:
     dependencies:
@@ -343,17 +343,17 @@ importers:
         version: link:../../vite-plugin-svelte-inline-component
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       '@testing-library/svelte':
         specifier: ^5.1.0
-        version: 5.1.0(svelte@4.0.0)(vite@5.2.11)(vitest@2.1.6)
+        version: 5.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))(vitest@2.1.6(@types/node@20.12.7)(jsdom@24.0.0))
       svelte:
         specifier: 4.x || 5.x
         version: 4.0.0
     devDependencies:
       svelte-preprocess:
         specifier: 5.1.4
-        version: 5.1.4(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
+        version: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
 
   packages/css: {}
 
@@ -373,7 +373,7 @@ importers:
         version: link:../types
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       esm-env:
         specifier: 1.0.0
         version: 1.0.0
@@ -406,7 +406,7 @@ importers:
         version: 0.0.1
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.17)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
       zod:
         specifier: 3.x
         version: 3.0.0
@@ -433,7 +433,7 @@ importers:
         version: link:../types
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.17)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
 
   packages/html-parser:
     dependencies:
@@ -452,6 +452,9 @@ importers:
 
   packages/i18n:
     dependencies:
+      '@288-toolkit/hooks':
+        specifier: workspace:*
+        version: link:../hooks
       '@288-toolkit/http':
         specifier: workspace:*
         version: link:../http
@@ -460,7 +463,7 @@ importers:
         version: link:../types
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       esm-env:
         specifier: 1.0.0
         version: 1.0.0
@@ -484,7 +487,7 @@ importers:
         version: link:../types
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       esm-env:
         specifier: 1.0.0
         version: 1.0.0
@@ -499,7 +502,7 @@ importers:
         version: link:../types
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       svelte:
         specifier: 4.x || 5.x
         version: 4.0.0
@@ -511,7 +514,7 @@ importers:
     dependencies:
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.17)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
 
   packages/timeout:
     dependencies:
@@ -537,7 +540,7 @@ importers:
         version: link:../device
       '@sveltejs/kit':
         specifier: ^2.5.1
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       svelte:
         specifier: 4.x || 5.x
         version: 4.0.0
@@ -561,11 +564,11 @@ importers:
         version: link:../strings
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.17)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
     devDependencies:
       vite-plugin-dts:
         specifier: ^3.9.0
-        version: 3.9.0(@types/node@20.12.7)(typescript@5.4.5)(vite@5.2.11)
+        version: 3.9.0(@types/node@20.12.7)(rollup@4.28.0)(typescript@5.4.5)(vite@5.2.11(@types/node@20.12.7))
 
   packages/vite-plugin-svelte-replacers:
     dependencies:
@@ -581,7 +584,7 @@ importers:
         version: 7.1.2(rollup@4.28.0)
       vite-plugin-dts:
         specifier: ^3.9.0
-        version: 3.9.0(@types/node@20.12.7)(rollup@4.28.0)(typescript@5.4.5)(vite@5.2.10)
+        version: 3.9.0(@types/node@20.12.7)(rollup@4.28.0)(typescript@5.4.5)(vite@5.2.11(@types/node@20.12.7))
 
   sandbox:
     dependencies:
@@ -591,19 +594,19 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: 3.2.0
-        version: 3.2.0(@sveltejs/kit@2.5.8)
+        version: 3.2.0(@sveltejs/kit@2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))
       '@sveltejs/kit':
         specifier: 2.5.8
-        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.17)(vite@5.2.11)
+        version: 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
       '@sveltejs/vite-plugin-svelte':
         specifier: 3.1.0
-        version: 3.1.0(svelte@4.2.17)(vite@5.2.11)
+        version: 3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
       '@types/eslint':
         specifier: 8.56.10
         version: 8.56.10
       '@typescript-eslint/eslint-plugin':
         specifier: 7.9.0
-        version: 7.9.0(@typescript-eslint/parser@7.9.0)(eslint@8.56.0)(typescript@5.4.5)
+        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)
       '@typescript-eslint/parser':
         specifier: 7.9.0
         version: 7.9.0(eslint@8.56.0)(typescript@5.4.5)
@@ -627,7 +630,7 @@ importers:
         version: 4.2.17
       svelte-check:
         specifier: 3.7.1
-        version: 3.7.1(postcss@8.4.49)(svelte@4.2.17)
+        version: 3.7.1(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.17)
       tslib:
         specifier: 2.6.2
         version: 2.6.2
@@ -960,15 +963,6 @@ packages:
 
   '@rollup/pluginutils@5.1.0':
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
-  '@rollup/pluginutils@5.1.3':
-    resolution: {integrity: sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
@@ -2639,10 +2633,6 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
-
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -4039,13 +4029,8 @@ snapshots:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 4.28.0
-
-  '@rollup/pluginutils@5.1.3':
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 4.0.2
 
   '@rollup/rollup-android-arm-eabi@4.28.0':
     optional: true
@@ -4103,13 +4088,14 @@ snapshots:
 
   '@rushstack/node-core-library@4.0.2(@types/node@20.12.7)':
     dependencies:
-      '@types/node': 20.12.7
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.8
       semver: 7.5.4
       z-schema: 5.0.5
+    optionalDependencies:
+      '@types/node': 20.12.7
 
   '@rushstack/rig-package@0.5.2':
     dependencies:
@@ -4119,8 +4105,9 @@ snapshots:
   '@rushstack/terminal@0.10.0(@types/node@20.12.7)':
     dependencies:
       '@rushstack/node-core-library': 4.0.2(@types/node@20.12.7)
-      '@types/node': 20.12.7
       supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 20.12.7
 
   '@rushstack/ts-command-line@4.19.1(@types/node@20.12.7)':
     dependencies:
@@ -4131,14 +4118,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@sveltejs/adapter-auto@3.2.0(@sveltejs/kit@2.5.8)':
+  '@sveltejs/adapter-auto@3.2.0(@sveltejs/kit@2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))':
     dependencies:
-      '@sveltejs/kit': 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.17)(vite@5.2.11)
+      '@sveltejs/kit': 2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/kit@2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.10)':
+  '@sveltejs/kit@2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.0.0)(vite@5.2.10)
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -4154,9 +4141,9 @@ snapshots:
       tiny-glob: 0.2.9
       vite: 5.2.10(@types/node@20.12.7)
 
-  '@sveltejs/kit@2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)':
+  '@sveltejs/kit@2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.0.0)(vite@5.2.11)
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -4172,9 +4159,9 @@ snapshots:
       tiny-glob: 0.2.9
       vite: 5.2.11(@types/node@20.12.7)
 
-  '@sveltejs/kit@2.5.8(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.17)(vite@5.2.11)':
+  '@sveltejs/kit@2.5.8(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.17)(vite@5.2.11)
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -4201,36 +4188,36 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.10)':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.0.0)(vite@5.2.10)
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7))
       debug: 4.3.7
       svelte: 4.0.0
       vite: 5.2.10(@types/node@20.12.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.0.0)(vite@5.2.11)
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       debug: 4.3.7
       svelte: 4.0.0
       vite: 5.2.11(@types/node@20.12.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.17)(vite@5.2.11)':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.17)(vite@5.2.11)
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
       debug: 4.3.7
       svelte: 4.2.17
       vite: 5.2.11(@types/node@20.12.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.10)':
+  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.10)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.10(@types/node@20.12.7))
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
@@ -4238,13 +4225,13 @@ snapshots:
       svelte: 4.0.0
       svelte-hmr: 0.16.0(svelte@4.0.0)
       vite: 5.2.10(@types/node@20.12.7)
-      vitefu: 0.2.5(vite@5.2.10)
+      vitefu: 0.2.5(vite@5.2.10(@types/node@20.12.7))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11)':
+  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.0.0)(vite@5.2.11)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
@@ -4252,13 +4239,13 @@ snapshots:
       svelte: 4.0.0
       svelte-hmr: 0.16.0(svelte@4.0.0)
       vite: 5.2.11(@types/node@20.12.7)
-      vitefu: 0.2.5(vite@5.2.11)
+      vitefu: 0.2.5(vite@5.2.11(@types/node@20.12.7))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11)':
+  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.17)(vite@5.2.11)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7)))(svelte@4.2.17)(vite@5.2.11(@types/node@20.12.7))
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
@@ -4266,7 +4253,7 @@ snapshots:
       svelte: 4.2.17
       svelte-hmr: 0.16.0(svelte@4.2.17)
       vite: 5.2.11(@types/node@20.12.7)
-      vitefu: 0.2.5(vite@5.2.11)
+      vitefu: 0.2.5(vite@5.2.11(@types/node@20.12.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -4292,17 +4279,11 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/svelte@5.1.0(svelte@4.0.0)(vite@5.2.10)(vitest@2.1.6)':
+  '@testing-library/svelte@5.1.0(svelte@4.0.0)(vite@5.2.11(@types/node@20.12.7))(vitest@2.1.6(@types/node@20.12.7)(jsdom@24.0.0))':
     dependencies:
       '@testing-library/dom': 9.3.4
       svelte: 4.0.0
-      vite: 5.2.10(@types/node@20.12.7)
-      vitest: 2.1.6(@types/node@20.12.7)(jsdom@24.0.0)
-
-  '@testing-library/svelte@5.1.0(svelte@4.0.0)(vite@5.2.11)(vitest@2.1.6)':
-    dependencies:
-      '@testing-library/dom': 9.3.4
-      svelte: 4.0.0
+    optionalDependencies:
       vite: 5.2.11(@types/node@20.12.7)
       vitest: 2.1.6(@types/node@20.12.7)(jsdom@24.0.0)
 
@@ -4335,7 +4316,7 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
-  '@typescript-eslint/eslint-plugin@7.7.1(@typescript-eslint/parser@7.7.1)(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@7.7.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       '@typescript-eslint/parser': 7.7.1(eslint@8.57.0)(typescript@5.4.5)
@@ -4350,11 +4331,12 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.6.3
       ts-api-utils: 1.4.3(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0)(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       '@typescript-eslint/parser': 7.9.0(eslint@8.56.0)(typescript@5.4.5)
@@ -4367,6 +4349,7 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       ts-api-utils: 1.4.3(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -4379,6 +4362,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.7.1
       debug: 4.3.7
       eslint: 8.57.0
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -4391,6 +4375,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.9.0
       debug: 4.3.7
       eslint: 8.56.0
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -4412,6 +4397,7 @@ snapshots:
       debug: 4.3.7
       eslint: 8.57.0
       ts-api-utils: 1.4.3(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -4423,6 +4409,7 @@ snapshots:
       debug: 4.3.7
       eslint: 8.56.0
       ts-api-utils: 1.4.3(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -4441,6 +4428,7 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.6.3
       ts-api-utils: 1.4.3(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -4455,6 +4443,7 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.6.3
       ts-api-utils: 1.4.3(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -4503,11 +4492,12 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.6(vite@5.2.11)':
+  '@vitest/mocker@2.1.6(vite@5.2.11(@types/node@20.12.7))':
     dependencies:
       '@vitest/spy': 2.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.14
+    optionalDependencies:
       vite: 5.2.11(@types/node@20.12.7)
 
   '@vitest/pretty-format@2.1.6':
@@ -4575,8 +4565,9 @@ snapshots:
       minimatch: 9.0.5
       muggle-string: 0.3.1
       path-browserify: 1.0.1
-      typescript: 5.4.5
       vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 5.4.5
 
   '@vue/shared@3.5.13': {}
 
@@ -5137,8 +5128,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      svelte: 4.0.0
       svelte-eslint-parser: 0.43.0(svelte@4.0.0)
+    optionalDependencies:
+      svelte: 4.0.0
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -5157,8 +5149,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      svelte: 4.2.17
       svelte-eslint-parser: 0.43.0(svelte@4.2.17)
+    optionalDependencies:
+      svelte: 4.2.17
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -5355,7 +5348,7 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@4.1.17(react-dom@18.3.1)(react@18.3.1):
+  framer-motion@4.1.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       framesync: 5.3.0
       hey-listen: 1.0.8
@@ -5880,14 +5873,15 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
-  motion@10.0.0(react-dom@18.3.1)(react@18.3.1):
+  motion@10.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      framer-motion: 4.1.17(react-dom@18.3.1)(react@18.3.1)
+      framer-motion: 4.1.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       popmotion: 9.4.2
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
       web-animations-js: 2.3.2
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   mri@1.2.0: {}
 
@@ -6024,8 +6018,6 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.2: {}
-
   pify@4.0.1: {}
 
   pkg-dir@4.2.0:
@@ -6051,8 +6043,9 @@ snapshots:
   postcss-load-config@3.1.4(postcss@8.4.49):
     dependencies:
       lilconfig: 2.1.0
-      postcss: 8.4.49
       yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.4.49
 
   postcss-safe-parser@6.0.0(postcss@8.4.49):
     dependencies:
@@ -6099,9 +6092,10 @@ snapshots:
       prettier: 3.2.5
       svelte: 4.2.17
 
-  prettier-plugin-tailwindcss@0.5.14(prettier-plugin-organize-imports@3.2.4)(prettier-plugin-svelte@3.2.3)(prettier@3.2.5):
+  prettier-plugin-tailwindcss@0.5.14(prettier-plugin-organize-imports@3.2.4(prettier@3.2.5)(typescript@5.4.5))(prettier-plugin-svelte@3.2.3(prettier@3.2.5)(svelte@4.0.0))(prettier@3.2.5):
     dependencies:
       prettier: 3.2.5
+    optionalDependencies:
       prettier-plugin-organize-imports: 3.2.4(prettier@3.2.5)(typescript@5.4.5)
       prettier-plugin-svelte: 3.2.3(prettier@3.2.5)(svelte@4.0.0)
 
@@ -6472,7 +6466,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.6.9(postcss@8.4.49)(svelte@4.0.0):
+  svelte-check@3.6.9(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
@@ -6481,7 +6475,7 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 4.0.0
-      svelte-preprocess: 5.1.4(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
+      svelte-preprocess: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6494,7 +6488,7 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-check@3.7.1(postcss@8.4.49)(svelte@4.2.17):
+  svelte-check@3.7.1(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.17):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
@@ -6503,7 +6497,7 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 4.2.17
-      svelte-preprocess: 5.1.4(postcss@8.4.49)(svelte@4.2.17)(typescript@5.4.5)
+      svelte-preprocess: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.17)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6527,6 +6521,7 @@ snapshots:
       espree: 9.6.1
       postcss: 8.4.49
       postcss-scss: 4.0.9(postcss@8.4.49)
+    optionalDependencies:
       svelte: 4.0.0
 
   svelte-eslint-parser@0.43.0(svelte@4.2.17):
@@ -6536,6 +6531,7 @@ snapshots:
       espree: 9.6.1
       postcss: 8.4.49
       postcss-scss: 4.0.9(postcss@8.4.49)
+    optionalDependencies:
       svelte: 4.2.17
 
   svelte-fsm@1.2.0: {}
@@ -6548,26 +6544,30 @@ snapshots:
     dependencies:
       svelte: 4.2.17
 
-  svelte-preprocess@5.1.4(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5):
+  svelte-preprocess@5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
       magic-string: 0.30.14
-      postcss: 8.4.49
       sorcery: 0.11.1
       strip-indent: 3.0.0
       svelte: 4.0.0
+    optionalDependencies:
+      postcss: 8.4.49
+      postcss-load-config: 3.1.4(postcss@8.4.49)
       typescript: 5.4.5
 
-  svelte-preprocess@5.1.4(postcss@8.4.49)(svelte@4.2.17)(typescript@5.4.5):
+  svelte-preprocess@5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.2.17)(typescript@5.4.5):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
       magic-string: 0.30.14
-      postcss: 8.4.49
       sorcery: 0.11.1
       strip-indent: 3.0.0
       svelte: 4.2.17
+    optionalDependencies:
+      postcss: 8.4.49
+      postcss-load-config: 3.1.4(postcss@8.4.49)
       typescript: 5.4.5
 
   svelte2tsx@0.7.28(svelte@4.0.0)(typescript@5.4.5):
@@ -6746,10 +6746,11 @@ snapshots:
 
   typescript-eslint@7.7.1(eslint@8.57.0)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.7.1(@typescript-eslint/parser@7.7.1)(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 7.7.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/parser': 7.7.1(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -6816,7 +6817,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@3.9.0(@types/node@20.12.7)(rollup@4.28.0)(typescript@5.4.5)(vite@5.2.10):
+  vite-plugin-dts@3.9.0(@types/node@20.12.7)(rollup@4.28.0)(typescript@5.4.5)(vite@5.2.11(@types/node@20.12.7)):
     dependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@20.12.7)
       '@rollup/pluginutils': 5.1.0(rollup@4.28.0)
@@ -6825,24 +6826,9 @@ snapshots:
       kolorist: 1.8.0
       magic-string: 0.30.14
       typescript: 5.4.5
-      vite: 5.2.10(@types/node@20.12.7)
       vue-tsc: 1.8.27(typescript@5.4.5)
-    transitivePeerDependencies:
-      - '@types/node'
-      - rollup
-      - supports-color
-
-  vite-plugin-dts@3.9.0(@types/node@20.12.7)(typescript@5.4.5)(vite@5.2.11):
-    dependencies:
-      '@microsoft/api-extractor': 7.43.0(@types/node@20.12.7)
-      '@rollup/pluginutils': 5.1.3
-      '@vue/language-core': 1.8.27(typescript@5.4.5)
-      debug: 4.3.7
-      kolorist: 1.8.0
-      magic-string: 0.30.14
-      typescript: 5.4.5
+    optionalDependencies:
       vite: 5.2.11(@types/node@20.12.7)
-      vue-tsc: 1.8.27(typescript@5.4.5)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -6850,35 +6836,34 @@ snapshots:
 
   vite@5.2.10(@types/node@20.12.7):
     dependencies:
-      '@types/node': 20.12.7
       esbuild: 0.20.2
       postcss: 8.4.49
       rollup: 4.28.0
     optionalDependencies:
+      '@types/node': 20.12.7
       fsevents: 2.3.3
 
   vite@5.2.11(@types/node@20.12.7):
     dependencies:
-      '@types/node': 20.12.7
       esbuild: 0.20.2
       postcss: 8.4.49
       rollup: 4.28.0
     optionalDependencies:
+      '@types/node': 20.12.7
       fsevents: 2.3.3
 
-  vitefu@0.2.5(vite@5.2.10):
-    dependencies:
+  vitefu@0.2.5(vite@5.2.10(@types/node@20.12.7)):
+    optionalDependencies:
       vite: 5.2.10(@types/node@20.12.7)
 
-  vitefu@0.2.5(vite@5.2.11):
-    dependencies:
+  vitefu@0.2.5(vite@5.2.11(@types/node@20.12.7)):
+    optionalDependencies:
       vite: 5.2.11(@types/node@20.12.7)
 
   vitest@2.1.6(@types/node@20.12.7)(jsdom@24.0.0):
     dependencies:
-      '@types/node': 20.12.7
       '@vitest/expect': 2.1.6
-      '@vitest/mocker': 2.1.6(vite@5.2.11)
+      '@vitest/mocker': 2.1.6(vite@5.2.11(@types/node@20.12.7))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.6
       '@vitest/snapshot': 2.1.6
@@ -6887,7 +6872,6 @@ snapshots:
       chai: 5.1.2
       debug: 4.3.7
       expect-type: 1.1.0
-      jsdom: 24.0.0
       magic-string: 0.30.14
       pathe: 1.1.2
       std-env: 3.8.0
@@ -6898,6 +6882,9 @@ snapshots:
       vite: 5.2.11(@types/node@20.12.7)
       vite-node: 2.1.6(@types/node@20.12.7)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.12.7
+      jsdom: 24.0.0
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
This is my solution to the whole site uri/handle locale/languages we had in the past weeks.

It decouples the i18n stuff from having to parse the url.
It also opens the door to more customization of the behavior in client projects.

It would be better to check the 3 commits by themselves, since they are done by package.