### PR TITLE
Fix `onMount` call in pagination

### DIFF
--- a/.changeset/chilled-ears-perform.md
+++ b/.changeset/chilled-ears-perform.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/pagination': patch
+---
+
+Fix `onMount` call breaking in svelte 5

--- a/packages/components/pagination/src/Pagination.svelte
+++ b/packages/components/pagination/src/Pagination.svelte
@@ -187,6 +187,8 @@
 		state.update(params);
 	};
 
+	// Calling `onMount` outside of component initialization like we do in the `update` event of the `idle` state below
+	// breaks in Svelte 5 so we need to store the value of `$mounted` in a reactive variable and use that instead
 	$: isMounted = $mounted;
 
 	const state = machine('idle', {

--- a/packages/components/pagination/src/Pagination.svelte
+++ b/packages/components/pagination/src/Pagination.svelte
@@ -187,10 +187,12 @@
 		state.update(params);
 	};
 
+	$: isMounted = $mounted;
+
 	const state = machine('idle', {
 		idle: {
 			update: () => {
-				if (!$mounted) {
+				if (!isMounted) {
 					return;
 				}
 				return 'loading';


### PR DESCRIPTION
This looks like a useless change but necessary for Svelte 5 compat.

Calling `onMount` outside of component initialization like we do in the `update` event of the `idle` state
breaks in Svelte 5 so we need to store the value of `$mounted` in a reactive variable and use that instead