### PR TITLE
(feat) Add validation to site handle in router

### DIFF
--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -199,8 +199,6 @@ export const createSiteRouter: <T extends SiteHandle = SiteHandle>(
 			}
 		}
 
-		
-
 		return resolve(event);
 	};
 };

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -28,13 +28,38 @@ type InternalSiteRouter<T extends SiteHandle = SiteHandle> = Omit<SiteRouter<T>,
  * Options for the siteRouter handle.
  */
 export type SiteRouterHandleOptions<T extends SiteHandle = SiteHandle> = {
+	/**
+	 * The default site uri. This is part of the public url
+	 */
 	defaultSiteUri: string;
+	/**
+	 * The default entry uri. This is part of the public url
+	 */
 	defaultEntryUri?: string;
+	/**
+	 * The default site handle. This might not be part of the public url and
+	 * is used to identify the craft site we want to fetch data from.
+	 */
 	defaultSiteHandle?: T;
+	/**
+	 * The valid site handles. This is used to validate the site handle.
+	 */
 	validSiteHandles?: T[];
+	/**
+	 * The site handle implementation. This is used to get the site handle from the request event.
+	 */
 	siteHandle?: (event: RequestEvent) => T;
+	/**
+	 * The pathname splitter. This is used to split the pathname into site and entry parts.
+	 */
 	pathnameSplitter?: (pathname: string) => string[];
+	/**
+	 * The parts to site router object. This is used to convert the parts array into a site router object.
+	 */
 	partsToSiteRouterObject?: (parts: string[], defaultEntryUri: string) => InternalSiteRouter<T>;
+	/**
+	 * The validate site handle. This is used to validate the site handle.
+	 */
 	validateSiteHandle?: (validSiteHandles: T[], possibleHandle: string) => boolean;
 };
 

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -79,7 +79,10 @@ export const defaultPartsToSiteRouterObject = <T extends SiteHandle = SiteHandle
  * @param event The request event.
  * @returns The formatted site handle.
  */
-export const defaultSiteHandleImplementation = <L extends SiteRouterLocals, T extends SiteHandle = SiteHandle>(
+export const defaultSiteHandleImplementation = <
+	L extends SiteRouterLocals,
+	T extends SiteHandle = SiteHandle
+>(
 	event: RequestEvent
 ) => {
 	const locals = event.locals as L;
@@ -112,15 +115,14 @@ export const defaultValidateSiteHandle = <T extends SiteHandle = SiteHandle>(
  * @param options The options for the siteRouter handle.
  * @returns The siteRouter handle.
  */
-export const createSiteRouter: <T extends SiteHandle = SiteHandle>(options: SiteRouterHandleOptions<T>) => Handle = <
-	L extends SiteRouterLocals<T>,
-	T extends SiteHandle = SiteHandle
->({
+export const createSiteRouter: <T extends SiteHandle = SiteHandle>(
+	options: SiteRouterHandleOptions<T>
+) => Handle = <L extends SiteRouterLocals<T>, T extends SiteHandle = SiteHandle>({
 	defaultSiteUri,
 	defaultSiteHandle = '' as T,
 	defaultEntryUri = '',
 	validSiteHandles = [],
-	siteHandle = defaultSiteHandleImplementation<L,T>,
+	siteHandle = defaultSiteHandleImplementation<L, T>,
 	pathnameSplitter = defaultPathnameSplitter,
 	partsToSiteRouterObject = defaultPartsToSiteRouterObject<T>,
 	validateSiteHandle = defaultValidateSiteHandle<T>

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -173,6 +173,12 @@ export const createSiteRouter: <T extends SiteHandle = SiteHandle>(
 			};
 		} else {
 			const internalSiteRouter = partsToSiteRouterObject(parts, defaultEntryUri);
+
+			// Make sure the site handle is set and properly formatted
+			if (!internalSiteRouter.site.handle) {
+				internalSiteRouter.site.handle = siteHandle(event);
+			}
+
 			if (validateSiteHandle(validSiteHandles, internalSiteRouter.site.handle)) {
 				locals.siteRouter = {
 					...internalSiteRouter,
@@ -193,10 +199,7 @@ export const createSiteRouter: <T extends SiteHandle = SiteHandle>(
 			}
 		}
 
-		// Make sure the site handle is set and properly formatted
-		if (!locals.siteRouter.site.handle) {
-			locals.siteRouter.site.handle = siteHandle(event);
-		}
+		
 
 		return resolve(event);
 	};

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -1,35 +1,48 @@
 import type { Handle, RequestEvent } from '@sveltejs/kit';
 
 /**
+ * The handle of the site.
+ */
+type SiteHandle = string;
+
+/**
  * The uri object with site and entry properties.
  */
-export type SiteRouter = {
+export type SiteRouter<T extends SiteHandle = SiteHandle> = {
 	default?: true;
+	valid: boolean;
+	parts: string[];
 	site: {
 		uri: string;
-		handle: string;
+		handle: T;
 	};
 	entry: {
 		uri: string;
 	};
 };
 
+// Used for internal validation purposes only
+type InternalSiteRouter<T extends SiteHandle = SiteHandle> = Omit<SiteRouter<T>, 'valid' | 'parts'>;
+
 /**
  * Options for the siteRouter handle.
  */
-export type SiteRouterHandleOptions = {
+export type SiteRouterHandleOptions<T extends SiteHandle = SiteHandle> = {
 	defaultSiteUri: string;
 	defaultEntryUri?: string;
-	siteHandle?: (event: RequestEvent) => string;
+	defaultSiteHandle?: T;
+	validSiteHandles?: T[];
+	siteHandle?: (event: RequestEvent) => T;
 	pathnameSplitter?: (pathname: string) => string[];
-	partsToSiteRouterObject?: (parts: string[], defaultEntryUri: string) => SiteRouter;
+	partsToSiteRouterObject?: (parts: string[], defaultEntryUri: string) => InternalSiteRouter<T>;
+	validateSiteHandle?: (validSiteHandles: T[], possibleHandle: string) => boolean;
 };
 
 /**
  * Let's make sure the locals object has the uri object with site and entry properties.
  */
-type SiteRouterLocals = App.Locals & {
-	siteRouter: SiteRouter;
+type SiteRouterLocals<T extends SiteHandle = SiteHandle> = App.Locals & {
+	siteRouter: SiteRouter<T>;
 };
 
 /**
@@ -46,16 +59,19 @@ export const defaultPathnameSplitter = (pathname: string) => pathname.split('/')
  * @param parts The parts to convert.
  * @returns The uri object.
  */
-export const defaultPartsToSiteRouterObject = (parts: string[], defaultEntryUri: string) =>
+export const defaultPartsToSiteRouterObject = <T extends SiteHandle = SiteHandle>(
+	parts: string[],
+	defaultEntryUri: string
+) =>
 	({
 		site: {
 			uri: parts[0],
-			handle: ''
+			handle: '' as T
 		},
 		entry: {
 			uri: parts.slice(1).map(decodeURIComponent).join('/') || defaultEntryUri
 		}
-	}) satisfies SiteRouter;
+	}) satisfies InternalSiteRouter<T>;
 
 /**
  * Default site handle formatter.
@@ -63,10 +79,23 @@ export const defaultPartsToSiteRouterObject = (parts: string[], defaultEntryUri:
  * @param event The request event.
  * @returns The formatted site handle.
  */
-export const defaultSiteHandle = <L extends SiteRouterLocals>(event: RequestEvent) => {
+export const defaultSiteHandleImplementation = <L extends SiteRouterLocals, T extends SiteHandle = SiteHandle>(
+	event: RequestEvent
+) => {
 	const locals = event.locals as L;
-	return locals.siteRouter.site.uri.replaceAll('-', '_');
+	return locals.siteRouter.site.uri.replaceAll('-', '_') as T;
 };
+
+/**
+ * Default site handle validator.
+ * This default implementation checks if the site handle is in the validSiteHandles array.
+ * @param handle The site handle to validate.
+ * @returns True if the site handle is valid, false otherwise.
+ */
+export const defaultValidateSiteHandle = <T extends SiteHandle = SiteHandle>(
+	validSiteHandles: T[],
+	possibleHandle: string
+) => Boolean(possibleHandle) && validSiteHandles.includes(possibleHandle as T);
 
 /**
  * This handle is responsible for setting the siteRouter object in the locals object.
@@ -78,36 +107,63 @@ export const defaultSiteHandle = <L extends SiteRouterLocals>(event: RequestEven
  * Those values will be used by other hooks and should also be used when requesting
  * an entry from the CMS.
  *
+ * If the url is empty or if the site handle is not valid, the default values will be used.
+ *
  * @param options The options for the siteRouter handle.
  * @returns The siteRouter handle.
  */
-export const createSiteRouter: (options: SiteRouterHandleOptions) => Handle = <
-	L extends SiteRouterLocals
+export const createSiteRouter: <T extends SiteHandle = SiteHandle>(options: SiteRouterHandleOptions<T>) => Handle = <
+	L extends SiteRouterLocals<T>,
+	T extends SiteHandle = SiteHandle
 >({
 	defaultSiteUri,
+	defaultSiteHandle = '' as T,
 	defaultEntryUri = '',
-	siteHandle = defaultSiteHandle,
+	validSiteHandles = [],
+	siteHandle = defaultSiteHandleImplementation<L,T>,
 	pathnameSplitter = defaultPathnameSplitter,
-	partsToSiteRouterObject = defaultPartsToSiteRouterObject
-}: SiteRouterHandleOptions) => {
+	partsToSiteRouterObject = defaultPartsToSiteRouterObject<T>,
+	validateSiteHandle = defaultValidateSiteHandle<T>
+}: SiteRouterHandleOptions<T>) => {
 	return <LL extends SiteRouterLocals = L>({ event, resolve }: Parameters<Handle>[0]) => {
 		const path = event.url.pathname;
 		const parts = pathnameSplitter(path);
 		const locals = event.locals as LL;
 
 		if (!parts.length) {
+			// If there are no parts, use the default site uri and entry uri
 			locals.siteRouter = {
 				default: true,
+				valid: true,
+				parts,
 				site: {
 					uri: defaultSiteUri,
-					handle: ''
+					handle: defaultSiteHandle
 				},
 				entry: {
 					uri: defaultEntryUri
 				}
 			};
 		} else {
-			locals.siteRouter = partsToSiteRouterObject(parts, defaultEntryUri);
+			const internalSiteRouter = partsToSiteRouterObject(parts, defaultEntryUri);
+			if (validateSiteHandle(validSiteHandles, internalSiteRouter.site.handle)) {
+				locals.siteRouter = {
+					...internalSiteRouter,
+					parts,
+					valid: true
+				};
+			} else {
+				locals.siteRouter = {
+					default: true,
+					valid: false,
+					parts,
+					site: {
+						uri: defaultSiteUri,
+						handle: defaultSiteHandle
+					},
+					entry: internalSiteRouter.entry
+				};
+			}
 		}
 
 		// Make sure the site handle is set and properly formatted


### PR DESCRIPTION
Without any validation, we are not able to properly fetch the globals, because we are passing a broken value.

As with other parts of this api, the validation logic can be overriden.