### PR TITLE
(fix) Make validateSiteHandle ReadonlyArray<T>

### DIFF
--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -105,9 +105,7 @@ export const defaultPartsToSiteRouterObject = <T extends SiteHandle = SiteHandle
  * @param siteRouter The site router object.
  * @returns The formatted site handle.
  */
-export const defaultSiteHandleImplementation = <
-	T extends SiteHandle = SiteHandle
->(
+export const defaultSiteHandleImplementation = <T extends SiteHandle = SiteHandle>(
 	_event: RequestEvent,
 	siteRouter: InternalSiteRouter<T>
 ) => {

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -48,7 +48,7 @@ export type SiteRouterHandleOptions<T extends SiteHandle = SiteHandle> = {
 	/**
 	 * The site handle implementation. This is used to get the site handle from the request event.
 	 */
-	siteHandle?: (event: RequestEvent) => T;
+	siteHandle?: (event: RequestEvent, siteRouter: InternalSiteRouter<T>) => T;
 	/**
 	 * The pathname splitter. This is used to split the pathname into site and entry parts.
 	 */
@@ -102,16 +102,16 @@ export const defaultPartsToSiteRouterObject = <T extends SiteHandle = SiteHandle
  * Default site handle formatter.
  * This default implementation replaces all '-' characters with '_' characters.
  * @param event The request event.
+ * @param siteRouter The site router object.
  * @returns The formatted site handle.
  */
 export const defaultSiteHandleImplementation = <
-	L extends SiteRouterLocals,
 	T extends SiteHandle = SiteHandle
 >(
-	event: RequestEvent
+	_event: RequestEvent,
+	siteRouter: InternalSiteRouter<T>
 ) => {
-	const locals = event.locals as L;
-	return locals.siteRouter.site.uri.replaceAll('-', '_') as T;
+	return siteRouter.site.uri.replaceAll('-', '_') as T;
 };
 
 /**
@@ -147,7 +147,7 @@ export const createSiteRouter: <T extends SiteHandle = SiteHandle>(
 	defaultSiteHandle = '' as T,
 	defaultEntryUri = '',
 	validSiteHandles = [],
-	siteHandle = defaultSiteHandleImplementation<L, T>,
+	siteHandle = defaultSiteHandleImplementation<T>,
 	pathnameSplitter = defaultPathnameSplitter,
 	partsToSiteRouterObject = defaultPartsToSiteRouterObject<T>,
 	validateSiteHandle = defaultValidateSiteHandle<T>
@@ -176,7 +176,7 @@ export const createSiteRouter: <T extends SiteHandle = SiteHandle>(
 
 			// Make sure the site handle is set and properly formatted
 			if (!internalSiteRouter.site.handle) {
-				internalSiteRouter.site.handle = siteHandle(event);
+				internalSiteRouter.site.handle = siteHandle(event, internalSiteRouter);
 			}
 
 			if (validateSiteHandle(validSiteHandles, internalSiteRouter.site.handle)) {

--- a/packages/hooks/src/server/site-router.ts
+++ b/packages/hooks/src/server/site-router.ts
@@ -44,7 +44,7 @@ export type SiteRouterHandleOptions<T extends SiteHandle = SiteHandle> = {
 	/**
 	 * The valid site handles. This is used to validate the site handle.
 	 */
-	validSiteHandles?: T[];
+	validSiteHandles?: ReadonlyArray<T>;
 	/**
 	 * The site handle implementation. This is used to get the site handle from the request event.
 	 */
@@ -60,7 +60,7 @@ export type SiteRouterHandleOptions<T extends SiteHandle = SiteHandle> = {
 	/**
 	 * The validate site handle. This is used to validate the site handle.
 	 */
-	validateSiteHandle?: (validSiteHandles: T[], possibleHandle: string) => boolean;
+	validateSiteHandle?: (validSiteHandles: ReadonlyArray<T>, possibleHandle: string) => boolean;
 };
 
 /**
@@ -121,7 +121,7 @@ export const defaultSiteHandleImplementation = <
  * @returns True if the site handle is valid, false otherwise.
  */
 export const defaultValidateSiteHandle = <T extends SiteHandle = SiteHandle>(
-	validSiteHandles: T[],
+	validSiteHandles: ReadonlyArray<T>,
 	possibleHandle: string
 ) => Boolean(possibleHandle) && validSiteHandles.includes(possibleHandle as T);
 


### PR DESCRIPTION
It must not changes, and our source values are also readonly

I've also fixed a bug: siteHandle does not need to know the locals, we already have all of the state at hand