### PR TITLE
(bc) Add tailwind v4 to peer deps

### DIFF
--- a/.changeset/shiny-ducks-hope.md
+++ b/.changeset/shiny-ducks-hope.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/css': major
+---
+
+Update to Tailwind v4

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -6,5 +6,8 @@
 	"type": "module",
 	"files": [
 		"*.css"
-	]
+	],
+	"peerDependencies": {
+		"tailwindcss": "4.x"
+	}
 }

--- a/packages/css/reset.css
+++ b/packages/css/reset.css
@@ -46,3 +46,8 @@ svg {
 	width: 100%;
 	height: auto;
 }
+
+button:not(:disabled),
+[role='button']:not(:disabled) {
+	cursor: pointer;
+}

--- a/packages/css/viewport.css
+++ b/packages/css/viewport.css
@@ -16,7 +16,7 @@
 	--viewport-ratio: calc(1000 / var(--viewport) * var(--factor));
 }
 
-@screen bp {
+@media (width >= theme(--breakpoint-bp)) {
 	:root {
 		--viewport: var(--viewport-desktop);
 		--factor: var(--factor-desktop);
@@ -31,7 +31,7 @@ html {
 	font-size: 56.25%;
 }
 
-@screen min {
+@media (width >= theme(--breakpoint-min)) {
 	html {
 		/**
 		* This is the magic part.
@@ -44,7 +44,7 @@ html {
 	}
 }
 
-@screen max {
+@media (width >= theme(--breakpoint-max)) {
 	html {
 		/**
 		* Cap rem to 10px

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,7 +355,11 @@ importers:
         specifier: 5.1.4
         version: 5.1.4(postcss-load-config@3.1.4(postcss@8.4.49))(postcss@8.4.49)(svelte@4.0.0)(typescript@5.4.5)
 
-  packages/css: {}
+  packages/css:
+    dependencies:
+      tailwindcss:
+        specifier: 4.x
+        version: 4.1.4
 
   packages/dates:
     dependencies:
@@ -3189,6 +3193,9 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwindcss@4.1.4:
+    resolution: {integrity: sha512-1ZIUqtPITFbv/DxRmDr5/agPqJwF69d24m9qmM1939TJehgY539CtzeZRjbLt5G6fSy/7YqqYsfvoTEw9xUI2A==}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -6611,6 +6618,8 @@ snapshots:
       periscopic: 3.1.0
 
   symbol-tree@3.2.4: {}
+
+  tailwindcss@4.1.4: {}
 
   term-size@2.2.1: {}
 


### PR DESCRIPTION
- Add Tailwind v4 to peer deps
- Add back `cursor: pointer;` on buttons, as Tailwind removed it from their `preflight.css` in v4
- Adjust media query syntax in `viewport.css`