### PR TITLE
(fix) Adjust release branch name

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -2,7 +2,7 @@ name: Changesets
 on:
     push:
         branches:
-            - releases
+            - release
 env:
     CI: true
 jobs:


### PR DESCRIPTION
The docs tell us to use the `release` branch, but the action uses the `releases` branch. It was less changes to modify the gh action, but if that causes a problem we can simply update the docs instead.