### PR TITLE
(chore) Depreciate scroll-to-anchor

### DIFF
--- a/.changeset/long-cooks-switch.md
+++ b/.changeset/long-cooks-switch.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/ui': patch
+---
+
+Depreciate scroll-to-anchor

--- a/packages/ui/src/scrollToAnchor.ts
+++ b/packages/ui/src/scrollToAnchor.ts
@@ -5,7 +5,7 @@ import { motionSafeScrollBehavior } from './motionSafeScrollBehavior.js';
  * This action will smoothly scroll to the anchor link's target if it exists while
  * preserving the browser's default behavior.
  * @param node The anchor link
- * 
+ *
  * @deprecated Use native anchor behavior with css property "scroll-behavior: smooth;" on html instead.
  */
 export const scrollToAnchor = (node: HTMLAnchorElement) => {

--- a/packages/ui/src/scrollToAnchor.ts
+++ b/packages/ui/src/scrollToAnchor.ts
@@ -5,6 +5,8 @@ import { motionSafeScrollBehavior } from './motionSafeScrollBehavior.js';
  * This action will smoothly scroll to the anchor link's target if it exists while
  * preserving the browser's default behavior.
  * @param node The anchor link
+ * 
+ * @deprecated Use native anchor behavior with css property "scroll-behavior: smooth;" on html instead.
  */
 export const scrollToAnchor = (node: HTMLAnchorElement) => {
 	const onClick = (e: MouseEvent) => {


### PR DESCRIPTION
As exeplained in the code, scroll-to-anchor behavior has been replaced with default anchor behavior with css property "scroll-behavior: smooth" on html.