### PR TITLE
(fix) Handle links nav with pop state

### DIFF
--- a/.changeset/dull-feet-lick.md
+++ b/.changeset/dull-feet-lick.md
@@ -1,0 +1,5 @@
+---
+'@288-toolkit/pagination': patch
+---
+
+Handle links nav with pop state

--- a/packages/components/pagination/src/Pagination.svelte
+++ b/packages/components/pagination/src/Pagination.svelte
@@ -152,9 +152,10 @@
 	// We need to update the initial page when the user navigates back to the page using
 	// the browser's back button. Since the page store is not updated when the user navigates
 	// back to the page, we need to update the pages store manually.
+	// This also happens if the user navigates to the same page using a link.
 	if (updateUrl) {
 		afterNavigate(({ type }) => {
-			if (type !== 'popstate') {
+			if (type !== 'popstate' && type !== 'link') {
 				return;
 			}
 			initialPage = getInitialPage();


### PR DESCRIPTION
This is required when a user clicks on a link on the same page.